### PR TITLE
Add associated stimulus id to the search results

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDto.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDto.java
@@ -21,6 +21,7 @@ public class ItemDto {
     private Instant createdAt;
     private List<StandardIdDto> standardIds;
     private Item itemDetail;
+    private String stimulusId;
 
     /**
      * @return the unique item id
@@ -86,6 +87,13 @@ public class ItemDto {
     }
 
     /**
+     * @return the item's associated stimulus id otherwise blank
+     */
+    public String getStimulusId() {
+        return stimulusId;
+    }
+
+    /**
      * @return the item detail as stored in the item bank
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -111,6 +119,7 @@ public class ItemDto {
         private Instant itemCreatedAt;
         private List<StandardIdDto> standardIds;
         private Item item;
+        private String stimlulusId;
 
         private Builder() {
         }
@@ -161,8 +170,13 @@ public class ItemDto {
         }
 
         public Builder withItem(Item item) {
-           this.item = item;
-           return this;
+            this.item = item;
+            return this;
+        }
+
+        public Builder withStimulusId(final String stimulusId) {
+            this.stimlulusId = stimulusId;
+            return this;
         }
 
         public ItemDto build() {
@@ -176,7 +190,8 @@ public class ItemDto {
             itemDto.id = this.id;
             itemDto.createdAt = this.itemCreatedAt;
             itemDto.depthOfKnowledge = this.depthOfKnowledge;
-            itemDto.itemDetail =item;
+            itemDto.itemDetail = item;
+            itemDto.stimulusId = stimlulusId;
             return itemDto;
         }
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoConverter.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoConverter.java
@@ -57,6 +57,7 @@ public class ItemDtoConverter extends DtoConverter<BaseItem, ItemDto> {
                 .withCreatedBy(domainObject.getItemCreatedBy())
                 .withItemType(domainObject.getItemType())
                 .withSubject(domainObject.getSubject())
+                .withStimulusId(domainObject.getAssociatedStimulusId())
                 .withWorkflowStatus(domainObject.getWorkflowStatus());
 
         List<StandardIdDto> standardIdDtos = domainObject.getStandardIds().stream()

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/builder/ImrtItemBuilder.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/builder/ImrtItemBuilder.java
@@ -22,6 +22,7 @@ public class ImrtItemBuilder {
     private Instant workflowStatusSetAt = Instant.now();
     private String organizationTypeId = "smarterBalanced";
     private String organizationName = "SB";
+    private String associatedStimulusId = "222333";
 
     public ImrtItemBuilder withKey(Integer key) {
         this.key = key;
@@ -90,6 +91,11 @@ public class ImrtItemBuilder {
 
     public ImrtItemBuilder withOrganizationName(String organizationName) {
         this.organizationName = organizationName;
+        return this;
+    }
+
+    public ImrtItemBuilder withAssociatedStimulusId(String associatedStimulusId) {
+        this.associatedStimulusId = associatedStimulusId;
         return this;
     }
 

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoConverterTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoConverterTest.java
@@ -47,6 +47,7 @@ public class ItemDtoConverterTest {
         assertThat(dto.getWorkflowStatus()).isEqualTo(item.getWorkflowStatus());
         assertThat(dto.getSubject()).isEqualTo(item.getSubject());
         assertThat(dto.getStandardIds()).hasSize(item.getStandardIds().size());
+        assertThat(dto.getStimulusId()).isEqualTo(item.getAssociatedStimulusId());
         assertThat(dto.getItemDetail()).isNotPresent();
     }
 
@@ -73,6 +74,7 @@ public class ItemDtoConverterTest {
         assertThat(dto.getCreatedAt()).isEqualTo(item.getItemCreatedAt());
         assertThat(dto.getGrade()).isEqualTo(item.getGrade());
         assertThat(dto.getItemType()).isEqualTo(item.getItemType());
+        assertThat(dto.getStimulusId()).isEqualTo(item.getAssociatedStimulusId());
         assertThat(dto.getWorkflowStatus()).isEqualTo(item.getWorkflowStatus());
         assertThat(dto.getSubject()).isEqualTo(item.getSubject());
         assertThat(dto.getStandardIds()).hasSize(item.getStandardIds().size());


### PR DESCRIPTION
I added the ability to search by stimulus id but didn't add it to the search results.