### PR TITLE
Fix sorting

### DIFF
--- a/documentation/general_search_api.md
+++ b/documentation/general_search_api.md
@@ -190,7 +190,7 @@ This is the `sort` property in the request body below.  This is not required and
 | Field | Description | Required | 
 | -------- | ----------- | -------- |
 | property   | the property to sort.  Align with filterable properties | yes 
-| order | "ASC" for ascending and "DESC" for descending | yes
+| direction | "ASC" for ascending and "DESC" for descending | yes
 
 ### Request Body
 
@@ -211,7 +211,7 @@ This is the `sort` property in the request body below.  This is not required and
 	],
 	"sort": {
 		"property": "itemId",
-		"order": "DESC"
+		"direction": "DESC"
 	},
 	"page": {
 		"size": 4,

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
@@ -118,7 +118,7 @@ public class ItemSearchServiceImpl implements ItemSearchService {
         }
 
         if(maybeSort.get().getDirection() == null) {
-            throw new IllegalArgumentException("Sort requires a \"direction\" value of ASC or DESC");
+            throw new IllegalArgumentException("Sort requires a 'direction' value of ASC or DESC");
         }
 
         Sort.Direction direction = ASC == maybeSort.get().getDirection() ? Sort.Direction.ASC : Sort.Direction.DESC;

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
@@ -117,6 +117,10 @@ public class ItemSearchServiceImpl implements ItemSearchService {
             return Optional.empty();
         }
 
+        if(maybeSort.get().getDirection() == null) {
+            throw new IllegalArgumentException("Sort requires a \"direction\" value of ASC or DESC");
+        }
+
         Sort.Direction direction = ASC == maybeSort.get().getDirection() ? Sort.Direction.ASC : Sort.Direction.DESC;
         return Optional.of(new Sort(direction, maybeImrtItemProperty.get()));
     }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImplIntegrationTest.java
@@ -310,6 +310,17 @@ public class ItemSearchServiceImplIntegrationTest {
         validateItemsIncludedInPage(result, "123", "345");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIfSortDirectionIsNotIncluded() {
+        final MatchFilter statusMatchFilter = new MatchFilter("workflowStatus", Collections.singletonList("Draft"));
+        final SearchRequest searchRequest =
+                new SearchRequest(Collections.singletonList(statusMatchFilter),
+                        new Sort("itemId", null),
+                        null);
+
+        itemSearchService.searchItems(searchRequest);
+    }
+
     @Test
     public void shouldFindAllItemsThatHaveBeenInDraftStatusToday() {
         final EqItem eq = new EqItem("123");


### PR DESCRIPTION
I had the documentation wrong so sort doesn't work.  Documentation has been updated plus added a check to throw if sort object is included without a direction.  If property isn't provided it is ignored.