### PR TITLE
IAT-2052: make core std and content domain fields countable

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/ItemSearchServiceImpl.java
@@ -32,13 +32,21 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.ITEM_TYPE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.ORG_NAME;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.ORG_TYPE_ID;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.PRIMARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.PRIMARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.PRIMARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.PRIMARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.QUATERNARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.QUATERNARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.QUATERNARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.QUATERNARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.SECONDARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.SECONDARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.SECONDARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.SECONDARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.SUBJECT;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TERTIARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TERTIARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TERTIARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TERTIARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TEST_CATEGORY;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WORKFLOW_STATUS;
@@ -69,12 +77,20 @@ public class ItemSearchServiceImpl implements ItemSearchService {
         //Alignment Fields
         countsToFields.put(PRIMARY_CLAIM, getImrtSearchProperty(PRIMARY_CLAIM).get());
         countsToFields.put(PRIMARY_TARGET, getImrtSearchProperty(PRIMARY_TARGET).get());
+        countsToFields.put(PRIMARY_COMMON_CORE_STANDARD, getImrtSearchProperty(PRIMARY_COMMON_CORE_STANDARD).get());
+        countsToFields.put(PRIMARY_CONTENT_DOMAIN, getImrtSearchProperty(PRIMARY_CONTENT_DOMAIN).get());
         countsToFields.put(SECONDARY_CLAIM, getImrtSearchProperty(SECONDARY_CLAIM).get());
         countsToFields.put(SECONDARY_TARGET, getImrtSearchProperty(SECONDARY_TARGET).get());
+        countsToFields.put(SECONDARY_COMMON_CORE_STANDARD, getImrtSearchProperty(SECONDARY_COMMON_CORE_STANDARD).get());
+        countsToFields.put(SECONDARY_CONTENT_DOMAIN, getImrtSearchProperty(SECONDARY_CONTENT_DOMAIN).get());
         countsToFields.put(QUATERNARY_CLAIM, getImrtSearchProperty(QUATERNARY_CLAIM).get());
         countsToFields.put(QUATERNARY_TARGET, getImrtSearchProperty(QUATERNARY_TARGET).get());
+        countsToFields.put(QUATERNARY_COMMON_CORE_STANDARD, getImrtSearchProperty(QUATERNARY_COMMON_CORE_STANDARD).get());
+        countsToFields.put(QUATERNARY_CONTENT_DOMAIN, getImrtSearchProperty(QUATERNARY_CONTENT_DOMAIN).get());
         countsToFields.put(TERTIARY_CLAIM, getImrtSearchProperty(TERTIARY_CLAIM).get());
         countsToFields.put(TERTIARY_TARGET, getImrtSearchProperty(TERTIARY_TARGET).get());
+        countsToFields.put(TERTIARY_COMMON_CORE_STANDARD, getImrtSearchProperty(TERTIARY_COMMON_CORE_STANDARD).get());
+        countsToFields.put(TERTIARY_CONTENT_DOMAIN, getImrtSearchProperty(TERTIARY_CONTENT_DOMAIN).get());
 
         COUNTS_TO_FIELDS = Collections.unmodifiableMap(countsToFields);
     }


### PR DESCRIPTION
[IAT-2052](https://jira.fairwaytech.com/browse/IAT-2052):  Make core standard and content domain fields countable