### PR TITLE
Feature/iat 2049

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compile 'biz.paluch.logging:logstash-gelf:1.12.0'
     compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
-    compile 'org.opentestsystem.ap:ap-common:0.4.17'
+    compile 'org.opentestsystem.ap:ap-common:0.4.20'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.assertj:assertj-core:3.9.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compile 'biz.paluch.logging:logstash-gelf:1.12.0'
-    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
+    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62'
     compile 'org.opentestsystem.ap:ap-common:0.4.20'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.assertj:assertj-core:3.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compile 'biz.paluch.logging:logstash-gelf:1.12.0'
-    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.61'
+    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
     compile 'org.opentestsystem.ap:ap-common:0.4.17'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.assertj:assertj-core:3.9.1'

--- a/documentation/Filters.md
+++ b/documentation/Filters.md
@@ -95,6 +95,10 @@ The **Integer Range Filter** allows for filtering items by a range of numbers.  
 | calculatedExposuresCount | All exposures across all forms |
 | itemDifficultyQuintile | The difficulty level of the item |
 | daysInWorkflowStatus | The number of days an item has been in the currently workflow status |
+| severeValidationResultCount | The number of validation results with a severity of `Severe` |
+| degradedValidationResultCount | The number of validation results with a severity of `Degraded` |
+| tolerableValidationResultCount | The number of validation results with a severity of `Tolerable` |
+| benignValidationResultCount | The number of validation results with a severity of `Benign` |
 
 **Example Usage**
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoModelConverter.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoModelConverter.java
@@ -140,7 +140,11 @@ public class ItemDtoModelConverter extends AbstractModelConverter<BaseItem, Item
                 .withIllustratedGlossaryProvided(convertToString(item.isIllustratedGlossaryProvided()))
                 .withIllustratedGlossaryRequired(item.getIllustratedGlossaryRequired())
                 .withTranslatedGlossaryProvided(convertToString(item.isTranslatedGlossaryProvided()))
-                .withTranslatedGlossaryRequired(item.getTranslatedGlossaryRequired());
+                .withTranslatedGlossaryRequired(item.getTranslatedGlossaryRequired())
+                .withSevereValidationResultCount(String.valueOf(item.getSevereValidationResultCount()))
+                .withDegradedValidationResultCount(String.valueOf(item.getDegradedValidationResultCount()))
+                .withTolerableValidationResultCount(String.valueOf(item.getTolerableValidationResultCount()))
+                .withBenignValidationResultCount(String.valueOf(item.getBenignValidationResultCount()));
     }
 
     private String convertToString(Object obj) {

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResult.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResult.java
@@ -89,6 +89,10 @@ public class ItemSearchResult {
     private String illustratedGlossaryRequired = EMPTY;
     private String translatedGlossaryProvided = EMPTY;
     private String translatedGlossaryRequired = EMPTY;
+    private String severeValidationResultCount = EMPTY;
+    private String degradedValidationResultCount = EMPTY;
+    private String tolerableValidationResultCount = EMPTY;
+    private String benignValidationResultCount = EMPTY;
 
     public static ItemSearchResultBuilder builder() {
         return ItemSearchResultBuilder.anItemSearchResultBuilder();
@@ -905,5 +909,37 @@ public class ItemSearchResult {
 
     void setTranslatedGlossaryRequired(final String translatedGlossaryRequired) {
         this.translatedGlossaryRequired = translatedGlossaryRequired;
+    }
+
+    public String getSevereValidationResultCount() {
+        return severeValidationResultCount;
+    }
+
+    public void setSevereValidationResultCount(final String severeValidationResultCount) {
+        this.severeValidationResultCount = severeValidationResultCount;
+    }
+
+    public String getDegradedValidationResultCount() {
+        return degradedValidationResultCount;
+    }
+
+    public void setDegradedValidationResultCount(final String degradedValidationResultCount) {
+        this.degradedValidationResultCount = degradedValidationResultCount;
+    }
+
+    public String getTolerableValidationResultCount() {
+        return tolerableValidationResultCount;
+    }
+
+    public void setTolerableValidationResultCount(final String tolerableValidationResultCount) {
+        this.tolerableValidationResultCount = tolerableValidationResultCount;
+    }
+
+    public String getBenignValidationResultCount() {
+        return benignValidationResultCount;
+    }
+
+    public void setBenignValidationResultCount(final String benignValidationResultCount) {
+        this.benignValidationResultCount = benignValidationResultCount;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResult.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResult.java
@@ -915,7 +915,7 @@ public class ItemSearchResult {
         return severeValidationResultCount;
     }
 
-    public void setSevereValidationResultCount(final String severeValidationResultCount) {
+    void setSevereValidationResultCount(final String severeValidationResultCount) {
         this.severeValidationResultCount = severeValidationResultCount;
     }
 
@@ -923,7 +923,7 @@ public class ItemSearchResult {
         return degradedValidationResultCount;
     }
 
-    public void setDegradedValidationResultCount(final String degradedValidationResultCount) {
+    void setDegradedValidationResultCount(final String degradedValidationResultCount) {
         this.degradedValidationResultCount = degradedValidationResultCount;
     }
 
@@ -931,7 +931,7 @@ public class ItemSearchResult {
         return tolerableValidationResultCount;
     }
 
-    public void setTolerableValidationResultCount(final String tolerableValidationResultCount) {
+    void setTolerableValidationResultCount(final String tolerableValidationResultCount) {
         this.tolerableValidationResultCount = tolerableValidationResultCount;
     }
 
@@ -939,7 +939,7 @@ public class ItemSearchResult {
         return benignValidationResultCount;
     }
 
-    public void setBenignValidationResultCount(final String benignValidationResultCount) {
+    void setBenignValidationResultCount(final String benignValidationResultCount) {
         this.benignValidationResultCount = benignValidationResultCount;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResultBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/ItemSearchResultBuilder.java
@@ -80,6 +80,10 @@ public class ItemSearchResultBuilder<B extends ItemSearchResultBuilder> {
     private String illustratedGlossaryRequired = EMPTY;
     private String translatedGlossaryProvided = EMPTY;
     private String translatedGlossaryRequired = EMPTY;
+    private String severeValidationResultCount = EMPTY;
+    private String degradedValidationResultCount = EMPTY;
+    private String tolerableValidationResultCount = EMPTY;
+    private String benignValidationResultCount = EMPTY;
 
     protected ItemSearchResultBuilder() {
     }
@@ -448,6 +452,26 @@ public class ItemSearchResultBuilder<B extends ItemSearchResultBuilder> {
         return (B) this;
     }
 
+    public B withSevereValidationResultCount(final String severeValidationResultCount) {
+        this.severeValidationResultCount = severeValidationResultCount;
+        return (B) this;
+    }
+
+    public B withDegradedValidationResultCount(final String degradedValidationResultCount) {
+        this.degradedValidationResultCount = degradedValidationResultCount;
+        return (B) this;
+    }
+
+    public B withTolerableValidationResultCount(final String tolerableValidationResultCount) {
+        this.tolerableValidationResultCount = tolerableValidationResultCount;
+        return (B) this;
+    }
+
+    public B withBenignValidationResultCount(final String benignValidationResultCount) {
+        this.benignValidationResultCount = benignValidationResultCount;
+        return (B) this;
+    }
+
     public ItemSearchResult build() {
         return build(new ItemSearchResult());
     }
@@ -525,6 +549,10 @@ public class ItemSearchResultBuilder<B extends ItemSearchResultBuilder> {
         itemSearchResult.setIllustratedGlossaryRequired(illustratedGlossaryRequired);
         itemSearchResult.setTranslatedGlossaryProvided(translatedGlossaryProvided);
         itemSearchResult.setTranslatedGlossaryRequired(translatedGlossaryRequired);
+        itemSearchResult.setSevereValidationResultCount(severeValidationResultCount);
+        itemSearchResult.setDegradedValidationResultCount(degradedValidationResultCount);
+        itemSearchResult.setTolerableValidationResultCount(tolerableValidationResultCount);
+        itemSearchResult.setBenignValidationResultCount(benignValidationResultCount);
         return itemSearchResult;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/Filter.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/Filter.java
@@ -76,6 +76,10 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_SIGHT_P
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_VISUAL_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_VISUAL_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.UPDATED_DATE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_BENIGN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_SEVERE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WORKFLOW_STATUS;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WORKFLOW_STATUS_UPDATE_DATE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WRITING_PURPOSE;
@@ -129,6 +133,10 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WRITING_PUR
         @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = ASSOCIATED_ITEM_COUNT),
         @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = ENGLISH_PASSAGES_COUNT),
         @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = SPANISH_PASSAGES_COUNT),
+        @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = VALIDATION_RESULT_SEVERITY_COUNT_SEVERE),
+        @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED),
+        @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE),
+        @JsonSubTypes.Type(value = IntegerRangeFilter.class, name = VALIDATION_RESULT_SEVERITY_COUNT_BENIGN),
         @JsonSubTypes.Type(value = BooleanFlagFilter.class, name = BEING_CREATED),
         @JsonSubTypes.Type(value = BooleanFlagFilter.class, name = TTS_SIGHT_PROVIDED),
         @JsonSubTypes.Type(value = BooleanFlagFilter.class, name = ASL_UPLOADED_PRIOR_TO_LAST_CONTENT_UPDATE),

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchFields.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchFields.java
@@ -80,4 +80,9 @@ public interface SearchFields {
     String ILLUSTRATED_GLOSSARY_REQUIRED = "isIllustratedGlossaryRequired";
     String TRANSLATED_GLOSSARY_PROVIDED = "isTranslatedGlossaryProvided";
     String TRANSLATED_GLOSSARY_REQUIRED = "isTranslatedGlossaryRequired";
+
+    String VALIDATION_RESULT_SEVERITY_COUNT_SEVERE = "severeValidationResultCount";
+    String VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED = "degradedValidationResultCount";
+    String VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE = "tolerableValidationResultCount";
+    String VALIDATION_RESULT_SEVERITY_COUNT_BENIGN = "benignValidationResultCount";
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchProperty.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchProperty.java
@@ -80,7 +80,11 @@ public enum SearchProperty {
     ILLUSTRATED_GLOSSARY_PROVIDED(SearchFields.ILLUSTRATED_GLOSSARY_PROVIDED, "illustrated_glossary_provided", "item", true),
     ILLUSTRATED_GLOSSARY_REQUIRED(SearchFields.ILLUSTRATED_GLOSSARY_REQUIRED, "illustrated_glossary_required", "item", true),
     TRANSLATED_GLOSSARY_PROVIDED(SearchFields.TRANSLATED_GLOSSARY_PROVIDED, "translated_glossary_provided", "item", true),
-    TRANSLATED_GLOSSARY_REQUIRED(SearchFields.TRANSLATED_GLOSSARY_REQUIRED, "translated_glossary_required", "item", true);
+    TRANSLATED_GLOSSARY_REQUIRED(SearchFields.TRANSLATED_GLOSSARY_REQUIRED, "translated_glossary_required", "item", true),
+    VALIDATION_RESULT_SEVERITY_COUNT_SEVERE(SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_SEVERE, "severe_validation_result_count", "item"),
+    VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED(SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED, "degraded_validation_result_count", "item"),
+    VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE(SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE, "tolerable_validation_result_count", "item"),
+    VALIDATION_RESULT_SEVERITY_COUNT_BENIGN(SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_BENIGN, "benign_validation_result_count", "item");
 
     private final String property;
     private final String columnName;

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/SearchFilterConverter.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/SearchFilterConverter.java
@@ -95,6 +95,10 @@ public class SearchFilterConverter extends AbstractModelConverter<Filter, Search
             case ITEM_DIFFICULTY_QUINTILE:
             case SPANISH_PASSAGES_COUNT:
             case ENGLISH_PASSAGES_COUNT:
+            case VALIDATION_RESULT_SEVERITY_COUNT_SEVERE:
+            case VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED:
+            case VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE:
+            case VALIDATION_RESULT_SEVERITY_COUNT_BENIGN:
                 return convertIntegerRangeFilter(filter);
             case FORM_TYPE:
             case ASSESSMENT_TYPE:

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GeneralSearchRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GeneralSearchRepositoryImpl.java
@@ -91,6 +91,10 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TTS_SIGHT
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TTS_VISUAL_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TTS_VISUAL_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.UPDATED_DATE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.VALIDATION_RESULT_SEVERITY_COUNT_BENIGN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.VALIDATION_RESULT_SEVERITY_COUNT_SEVERE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS_UPDATE_DATE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WRITING_PURPOSE;
@@ -170,6 +174,11 @@ public class GeneralSearchRepositoryImpl implements GeneralSearchRepository {
             ILLUSTRATED_GLOSSARY_PROVIDED.getColumnName() + ", \n" +
             TRANSLATED_GLOSSARY_PROVIDED.getColumnName() + ", \n" +
             TRANSLATED_GLOSSARY_REQUIRED.getColumnName() + ", \n" +
+            VALIDATION_RESULT_SEVERITY_COUNT_SEVERE.getColumnName() + ", \n" +
+            VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED.getColumnName() + ", \n" +
+            VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE.getColumnName() + ", \n" +
+            VALIDATION_RESULT_SEVERITY_COUNT_BENIGN.getColumnName() + ", \n" +
+
             "(select count(1) from stim_link where item_key_stim = item.key) as " + SearchProperty.ASSOCIATED_ITEM_COUNT.getColumnName() + " \n" +
             "FROM item \n";
 
@@ -272,7 +281,11 @@ public class GeneralSearchRepositoryImpl implements GeneralSearchRepository {
                     .withIllustratedGlossaryProvided(mapToString(rs, ILLUSTRATED_GLOSSARY_PROVIDED.getColumnName()))
                     .withIllustratedGlossaryRequired(defaultString(rs.getString(ILLUSTRATED_GLOSSARY_REQUIRED.getColumnName())))
                     .withTranslatedGlossaryProvided(mapToString(rs, TRANSLATED_GLOSSARY_PROVIDED.getColumnName()))
-                    .withTranslatedGlossaryRequired(defaultString(rs.getString(TRANSLATED_GLOSSARY_REQUIRED.getColumnName())));
+                    .withTranslatedGlossaryRequired(defaultString(rs.getString(TRANSLATED_GLOSSARY_REQUIRED.getColumnName())))
+                    .withSevereValidationResultCount(String.valueOf(rs.getInt(VALIDATION_RESULT_SEVERITY_COUNT_SEVERE.getColumnName())))
+                    .withDegradedValidationResultCount(String.valueOf(rs.getInt(VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED.getColumnName())))
+                    .withTolerableValidationResultCount(String.valueOf(rs.getInt(VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE.getColumnName())))
+                    .withBenignValidationResultCount(String.valueOf(rs.getInt(VALIDATION_RESULT_SEVERITY_COUNT_BENIGN.getColumnName())));
 
             return builder.build();
         });

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/builder/BaseItemBuilder.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/builder/BaseItemBuilder.java
@@ -97,6 +97,11 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
     private boolean translatedGlossaryProvided = true;
     private String translatedGlossaryRequired = "Yes";
 
+    private int severeValidationResultCount = 0;
+    private int degradedValidationResultCount = 1;
+    private int tolerableValidationResultCount = 2;
+    private int benignValidationResultCount = 3;
+
     public B withKey(Integer key) {
         this.key = key;
         return (B) this;
@@ -468,6 +473,26 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         return (B) this;
     }
 
+    public B withSevereValidationResultCount(final int severeValidationResultCount) {
+        this.severeValidationResultCount = severeValidationResultCount;
+        return (B) this;
+    }
+
+    public B withDegradedValidationResultCount(final int degradedValidationResultCount) {
+        this.degradedValidationResultCount = degradedValidationResultCount;
+        return (B) this;
+    }
+
+    public B withTolerableValidationResultCount(final int tolerableValidationResultCount) {
+        this.tolerableValidationResultCount = tolerableValidationResultCount;
+        return (B) this;
+    }
+
+    public B withBenignValidationResultCount(final int benignValidationResultCount) {
+        this.benignValidationResultCount = benignValidationResultCount;
+        return (B) this;
+    }
+
     T build(T item) {
         super.build(item);
         item.setKey(key);
@@ -544,6 +569,10 @@ public abstract class BaseItemBuilder<B extends BaseItemBuilder, T extends BaseI
         item.setIllustratedGlossaryRequired(illustratedGlossaryRequired);
         item.setTranslatedGlossaryProvided(translatedGlossaryProvided);
         item.setTranslatedGlossaryRequired(translatedGlossaryRequired);
+        item.setSevereValidationResultCount(severeValidationResultCount);
+        item.setDegradedValidationResultCount(degradedValidationResultCount);
+        item.setTolerableValidationResultCount(tolerableValidationResultCount);
+        item.setBenignValidationResultCount(benignValidationResultCount);
         return item;
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoModelConverterTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/dto/ItemDtoModelConverterTest.java
@@ -172,6 +172,12 @@ public class ItemDtoModelConverterTest {
         assertThat(dto.getIllustratedGlossaryRequired()).isEqualTo(item.getIllustratedGlossaryRequired());
         assertThat(dto.getIllustratedGlossaryProvided()).isEqualTo(String.valueOf(item.isIllustratedGlossaryProvided()));
         assertThat(dto.getTranslatedGlossaryRequired()).isEqualTo(item.getTranslatedGlossaryRequired());
+
+        assertThat(dto.getSevereValidationResultCount()).isEqualTo(String.valueOf(item.getSevereValidationResultCount()));
+        assertThat(dto.getDegradedValidationResultCount()).isEqualTo(String.valueOf(item.getDegradedValidationResultCount()));
+        assertThat(dto.getTolerableValidationResultCount()).isEqualTo(String.valueOf(item.getTolerableValidationResultCount()));
+        assertThat(dto.getBenignValidationResultCount()).isEqualTo(String.valueOf(item.getBenignValidationResultCount()));
+
         if (item instanceof Stimulus) {
             assertThat(dto.getAssociatedItemCount()).isEqualTo(String.valueOf(((Stimulus) item).getAssociatedItems().size()));
         } else {

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchPropertyTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/dto/search/SearchPropertyTest.java
@@ -82,7 +82,11 @@ public class SearchPropertyTest {
             SearchFields.ILLUSTRATED_GLOSSARY_PROVIDED,
             SearchFields.ILLUSTRATED_GLOSSARY_REQUIRED,
             SearchFields.TRANSLATED_GLOSSARY_PROVIDED,
-            SearchFields.TRANSLATED_GLOSSARY_REQUIRED
+            SearchFields.TRANSLATED_GLOSSARY_REQUIRED,
+            SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_SEVERE,
+            SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED,
+            SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE,
+            SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_BENIGN
     );
 
     @Test

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/model/SearchFilterConverterTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/model/SearchFilterConverterTest.java
@@ -90,6 +90,10 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_SIGHT_P
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_VISUAL_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.TTS_VISUAL_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.UPDATED_DATE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_BENIGN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_SEVERE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WORKFLOW_STATUS;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WORKFLOW_STATUS_UPDATE_DATE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchFields.WRITING_PURPOSE;
@@ -155,7 +159,11 @@ public class SearchFilterConverterTest {
             ITEM_DIFFICULTY_QUINTILE,
             ENGLISH_PASSAGES_COUNT,
             SPANISH_PASSAGES_COUNT,
-            ASSOCIATED_ITEM_COUNT);
+            ASSOCIATED_ITEM_COUNT,
+            VALIDATION_RESULT_SEVERITY_COUNT_SEVERE,
+            VALIDATION_RESULT_SEVERITY_COUNT_DEGRADED,
+            VALIDATION_RESULT_SEVERITY_COUNT_TOLERABLE,
+            VALIDATION_RESULT_SEVERITY_COUNT_BENIGN);
 
     private final static List<String> booleanFlagFilterProperties = Arrays.asList(
             BEING_CREATED,

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/ItemSearchResultConverter.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/ItemSearchResultConverter.java
@@ -80,7 +80,11 @@ class ItemSearchResultConverter {
                 .withIllustratedGlossaryProvided(convertToString(item.isIllustratedGlossaryProvided()))
                 .withIllustratedGlossaryRequired(item.getIllustratedGlossaryRequired())
                 .withTranslatedGlossaryProvided(convertToString(item.isTranslatedGlossaryProvided()))
-                .withTranslatedGlossaryRequired(item.getTranslatedGlossaryRequired());
+                .withTranslatedGlossaryRequired(item.getTranslatedGlossaryRequired())
+                .withSevereValidationResultCount(convertToString(item.getSevereValidationResultCount()))
+                .withDegradedValidationResultCount(convertToString(item.getDegradedValidationResultCount()))
+                .withTolerableValidationResultCount(convertToString(item.getTolerableValidationResultCount()))
+                .withBenignValidationResultCount(convertToString(item.getBenignValidationResultCount()));
 
         return builder.build();
     }


### PR DESCRIPTION
[IAT-2049](https://jira.fairwaytech.com/browse/IAT-2049):  Add fields for validation results count fields.

### Additional Notes
After testing a query that would get the counts from the `validation_result` table for each of the severity levels, I decided it would be better to store the counts whenever the item is submitted to the validation service.