### PR TITLE
Feature/iat 2095

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -1,6 +1,5 @@
 package org.opentestsystem.ap.imrt.iss.controller;
 
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.opentestsystem.ap.common.exception.ResourceNotFoundException;
 import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
 import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
@@ -9,6 +8,7 @@ import org.opentestsystem.ap.imrt.iss.model.ModelConverter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.opentestsystem.ap.imrt.iss.service.GapReportService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,10 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,28 +35,23 @@ public class ReportController {
         this.searchFilterModelConverter = searchFilterModelConverter;
     }
 
-    @PostMapping(value = "gap")
+    @PostMapping(value = "gap", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
-    public void getGapReport(@RequestBody final GapReportRequest gapReportRequest,
-                             final HttpServletResponse response) {
+    public FileSystemResource getGapReport(@RequestBody final GapReportRequest gapReportRequest,
+                                           final HttpServletResponse response) {
         final List<SearchFilter> filters = searchFilterModelConverter.convert(gapReportRequest.getFilters());
         final List<SearchProperty> groups = gapReportRequest.getGroups().stream()
                 .map(groupByString -> SearchProperty.findSearchProperty(groupByString)
                         .orElseThrow(() -> new IllegalArgumentException("Invalid group property in request " + groupByString)))
                 .collect(Collectors.toList());
 
-        final XSSFWorkbook workbook = gapReportService.getGapReport(filters, groups)
+        final File workbook = gapReportService.getGapReport(filters, groups)
                 .orElseThrow(() -> new ResourceNotFoundException("could not get Excel file"));
 
-        try {
-            final DateFormat df = new SimpleDateFormat("yyyyMMddhhmmss");
-            response.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-            response.setHeader("Content-disposition", "attachment; filename=gap-report-" + df.format(new Date()) + ".xlsx");
+        response.setHeader("Content-Disposition", "attachment; filename=" + workbook.getName());
+        response.setHeader("Content-Length", String.valueOf(workbook.length()));
 
-            workbook.write(response.getOutputStream());
-        } catch (final IOException e) {
-            throw new RuntimeException("Error occurred while returning Gap Report Excel file: " + e.getMessage());
-        }
+        return new FileSystemResource(workbook);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -1,0 +1,47 @@
+package org.opentestsystem.ap.imrt.iss.controller;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
+import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.ModelConverter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.service.GapReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("v1/items/reports")
+public class ReportController {
+    private final GapReportService gapReportService;
+    private final ModelConverter<Filter, SearchFilter> searchFilterModelConverter;
+
+    @Autowired
+    public ReportController(final GapReportService gapReportService,
+                            final ModelConverter<Filter, SearchFilter> searchFilterModelConverter) {
+        this.gapReportService = gapReportService;
+        this.searchFilterModelConverter = searchFilterModelConverter;
+    }
+
+    @PostMapping(value = "gap", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GapReport> getGapReport(@RequestBody final GapReportRequest gapReportRequest) {
+        final List<SearchFilter> filters = searchFilterModelConverter.convert(gapReportRequest.getFilters());
+        final List<SearchProperty> groups = gapReportRequest.getGroups().stream()
+                .map(groupByString -> SearchProperty.findSearchProperty(groupByString)
+                        .orElseThrow(() -> new IllegalArgumentException("Invalid group property in request " + groupByString)))
+                .collect(Collectors.toList());
+
+        final Optional<GapReport> gapReport = gapReportService.getGapReport(filters, groups);
+
+        return ResponseEntity.ok(gapReport.get());
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -1,22 +1,27 @@
 package org.opentestsystem.ap.imrt.iss.controller;
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.opentestsystem.ap.common.exception.ResourceNotFoundException;
 import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
 import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.ModelConverter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
 import org.opentestsystem.ap.imrt.iss.service.GapReportService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -32,16 +37,28 @@ public class ReportController {
         this.searchFilterModelConverter = searchFilterModelConverter;
     }
 
-    @PostMapping(value = "gap", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<GapReport> getGapReport(@RequestBody final GapReportRequest gapReportRequest) {
+    @PostMapping(value = "gap")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public void getGapReport(@RequestBody final GapReportRequest gapReportRequest,
+                             final HttpServletResponse response) {
         final List<SearchFilter> filters = searchFilterModelConverter.convert(gapReportRequest.getFilters());
         final List<SearchProperty> groups = gapReportRequest.getGroups().stream()
                 .map(groupByString -> SearchProperty.findSearchProperty(groupByString)
                         .orElseThrow(() -> new IllegalArgumentException("Invalid group property in request " + groupByString)))
                 .collect(Collectors.toList());
 
-        final Optional<GapReport> gapReport = gapReportService.getGapReport(filters, groups);
+        final XSSFWorkbook workbook = gapReportService.getGapReport(filters, groups)
+                .orElseThrow(() -> new ResourceNotFoundException("could not get Excel file"));
 
-        return ResponseEntity.ok(gapReport.get());
+        try {
+            final DateFormat df = new SimpleDateFormat("yyyyMMddhhmmss");
+            response.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-disposition", "attachment; filename=gap-report-" + df.format(new Date()) + ".xlsx");
+
+            workbook.write(response.getOutputStream());
+        } catch (final Exception e) {
+            throw new RuntimeException("Error occurred while getting Gap Report Excel file: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -35,7 +35,7 @@ public class ReportController {
         this.searchFilterModelConverter = searchFilterModelConverter;
     }
 
-    @PostMapping(value = "gap", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    @PostMapping(value = "gap")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public FileSystemResource getGapReport(@RequestBody final GapReportRequest gapReportRequest,
@@ -49,6 +49,7 @@ public class ReportController {
         final File workbook = gapReportService.getGapReport(filters, groups)
                 .orElseThrow(() -> new ResourceNotFoundException("could not get Gap Report file"));
 
+        response.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setHeader("Content-Disposition", "attachment; filename=" + workbook.getName());
         response.setHeader("Content-Length", String.valueOf(workbook.length()));
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -42,12 +42,12 @@ public class ReportController {
                                            final HttpServletResponse response) {
         final List<SearchFilter> filters = searchFilterModelConverter.convert(gapReportRequest.getFilters());
         final List<SearchProperty> groups = gapReportRequest.getGroups().stream()
-                .map(groupByString -> SearchProperty.findSearchProperty(groupByString)
-                        .orElseThrow(() -> new IllegalArgumentException("Invalid group property in request " + groupByString)))
+                .map(group -> SearchProperty.findSearchProperty(group)
+                        .orElseThrow(() -> new IllegalArgumentException("Invalid group property in request " + group)))
                 .collect(Collectors.toList());
 
         final File workbook = gapReportService.getGapReport(filters, groups)
-                .orElseThrow(() -> new ResourceNotFoundException("could not get Excel file"));
+                .orElseThrow(() -> new ResourceNotFoundException("could not get Gap Report file"));
 
         response.setHeader("Content-Disposition", "attachment; filename=" + workbook.getName());
         response.setHeader("Content-Length", String.valueOf(workbook.length()));

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -57,8 +58,8 @@ public class ReportController {
             response.setHeader("Content-disposition", "attachment; filename=gap-report-" + df.format(new Date()) + ".xlsx");
 
             workbook.write(response.getOutputStream());
-        } catch (final Exception e) {
-            throw new RuntimeException("Error occurred while getting Gap Report Excel file: " + e.getMessage());
+        } catch (final IOException e) {
+            throw new RuntimeException("Error occurred while returning Gap Report Excel file: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/controller/ReportController.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.ap.imrt.iss.controller;
 
-import org.opentestsystem.ap.common.exception.ResourceNotFoundException;
+
+import org.opentestsystem.ap.imrt.common.exception.NotFoundException;
 import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
 import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
@@ -47,7 +48,7 @@ public class ReportController {
                 .collect(Collectors.toList());
 
         final File workbook = gapReportService.getGapReport(filters, groups)
-                .orElseThrow(() -> new ResourceNotFoundException("could not get Gap Report file"));
+                .orElseThrow(() -> new NotFoundException("could not get Gap Report file"));
 
         response.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setHeader("Content-Disposition", "attachment; filename=" + workbook.getName());

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
@@ -1,0 +1,34 @@
+package org.opentestsystem.ap.imrt.iss.dto.search;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opentestsystem.ap.imrt.iss.util.Preconditions;
+
+import java.util.List;
+
+/**
+ * Provide the information necessary to generate a Gap Report.
+ */
+public class GapReportRequest {
+    private final List<Filter> filters;
+    private final List<String> groups;
+
+    public GapReportRequest(@JsonProperty("filters") final List<Filter> filters,
+                            @JsonProperty("groups") final List<String> groups) {
+        this.filters = Preconditions.checkNotNull(filters, "filters is required");
+        this.groups = Preconditions.checkNotNull(groups, "groups is required");
+    }
+
+    /**
+     * @return
+     */
+    public List<Filter> getFilters() {
+        return filters;
+    }
+
+    /**
+     * @return
+     */
+    public List<String> getGroups() {
+        return groups;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
@@ -19,16 +19,24 @@ public class GapReportRequest {
     }
 
     /**
-     * @return
+     * @return The collection of {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s provided by the user to
+     * generate the report
      */
     public List<Filter> getFilters() {
         return filters;
     }
 
     /**
-     * @return
+     * @return The collection of {@link String}s describing the fields the user wants to group the difficulty quintile
+     * counts by
      */
     public List<String> getGroups() {
         return groups;
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format("GapReportRequest{filters=%s, groups=%s", filters, groups);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
@@ -34,7 +34,6 @@ public class GapReportRequest {
         return groups;
     }
 
-
     @Override
     public String toString() {
         return String.format("GapReportRequest{filters=%s, groups=%s}", filters, groups);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/GapReportRequest.java
@@ -37,6 +37,6 @@ public class GapReportRequest {
 
     @Override
     public String toString() {
-        return String.format("GapReportRequest{filters=%s, groups=%s", filters, groups);
+        return String.format("GapReportRequest{filters=%s, groups=%s}", filters, groups);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/Sort.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/dto/search/Sort.java
@@ -23,7 +23,7 @@ public class Sort {
     public Sort(@JsonProperty("property") final String property,
                 @JsonProperty("direction") final Direction direction) {
         this.property = SearchProperty.findSearchProperty(Preconditions.checkNotNull(property))
-                .orElseThrow(() -> new IllegalArgumentException("Do not recognized sort property " + property));
+                .orElseThrow(() -> new IllegalArgumentException("Do not recognize sort property " + property));
         this.direction = Preconditions.checkNotNull(direction);
     }
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/IntegerRangeSearchFilter.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/IntegerRangeSearchFilter.java
@@ -26,13 +26,17 @@ public class IntegerRangeSearchFilter extends AbstractSearchFilter implements Se
         this.max = max;
     }
 
-    @VisibleForTesting
-    Integer getMin() {
+    /**
+     * @return The lower-bound of this filter
+     */
+    public Integer getMin() {
         return min;
     }
 
-    @VisibleForTesting
-    Integer getMax() {
+    /**
+     * @return The upper-bound of this filter
+     */
+    public Integer getMax() {
         return max;
     }
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReport.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReport.java
@@ -1,0 +1,33 @@
+package org.opentestsystem.ap.imrt.iss.model.reports.gap;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class GapReport {
+    private final Collection<Filter> filters;
+    private final Collection<String> groupFilters;
+    private final List<Map<String, Object>> gapReportRecords;
+
+    public GapReport(final Collection<Filter> filters,
+                     final Collection<String> groupFilters,
+                     final List<Map<String, Object>> gapReportRecords) {
+        this.filters = filters;
+        this.groupFilters = groupFilters;
+        this.gapReportRecords = gapReportRecords;
+    }
+
+    public Collection<Filter> getFilters() {
+        return filters;
+    }
+
+    public Collection<String> getGroupFilters() {
+        return groupFilters;
+    }
+
+    public List<Map<String, Object>> getGapReportRecords() {
+        return gapReportRecords;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReport.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReport.java
@@ -1,33 +1,60 @@
 package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 
-import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Store all the information required for the Gap Report output.
+ */
 public class GapReport {
-    private final Collection<Filter> filters;
-    private final Collection<String> groupFilters;
+    private final Collection<SearchFilter> filters;
+    private final Collection<SearchProperty> groupFilters;
     private final List<Map<String, Object>> gapReportRecords;
+    private final Instant createdDate;
 
-    public GapReport(final Collection<Filter> filters,
-                     final Collection<String> groupFilters,
-                     final List<Map<String, Object>> gapReportRecords) {
+    public GapReport(final Collection<SearchFilter> filters,
+                     final Collection<SearchProperty> groupFilters,
+                     final List<Map<String, Object>> gapReportRecords,
+                     final Instant createdDate) {
         this.filters = filters;
         this.groupFilters = groupFilters;
         this.gapReportRecords = gapReportRecords;
+        this.createdDate = createdDate;
     }
 
-    public Collection<Filter> getFilters() {
+    /**
+     * @return The {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s used to find the data that appears on the
+     * report.
+     */
+    public Collection<SearchFilter> getFilters() {
         return filters;
     }
 
-    public Collection<String> getGroupFilters() {
+    /**
+     * @return The {@link org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty}s to determine which columns should
+     * appear on the report and how the difficulty quintile counts should be grouped.
+     */
+    public Collection<SearchProperty> getGroupFilters() {
         return groupFilters;
     }
 
+    /**
+     * @return A {@link java.util.List} of rows containing the data for the Gap Report.  Each row is a
+     * {@link java.util.Map} with a key == the name of the database column and value == the column's value.
+     */
     public List<Map<String, Object>> getGapReportRecords() {
         return gapReportRecords;
+    }
+
+    /**
+     * @return The {@link java.time.Instant} when this Gap Report was created.
+     */
+    public Instant getCreatedDate() {
+        return createdDate;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -327,8 +327,14 @@ public class GapReportBuilder {
             }
 
             // Add formulae
-            if (key.matches("^([Aa]ctual|[Dd]esired).+")) {
+            if (key.toLowerCase().startsWith("actual") || key.equals(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase())) {
                 desiredAndActualIndexMap.put(key, cellIndex);
+            }
+
+            if (key.matches("^[Dd]esired.*[1-5]")) {
+                desiredAndActualIndexMap.put(key, cellIndex);
+                final Cell desiredCountCell = row.getCell(desiredAndActualIndexMap.get(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase()));
+                detailCell.setCellFormula(String.format("IF(ISNUMBER(%1$s),FLOOR(%s/5,1),\"\")", desiredCountCell.getAddress().formatAsString()));
             }
 
             if (key.matches("^([Dd]elta).*")) {

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -234,7 +234,7 @@ public class GapReportBuilder {
         for (final SearchProperty group : gapReport.getGroupFilters()) {
             if (groupsHeaderRow.getLastCellNum() == 1) {
                 final XSSFCell firstGroupValueCell = groupsHeaderRow.createCell(groupsHeaderRow.getLastCellNum());
-                firstGroupValueCell.setCellValue(group.getProperty());
+                firstGroupValueCell.setCellValue(columnNameToLabelMap.get(group.getProperty().toLowerCase()));
             } else {
                 final XSSFRow groupRow = reportParametersSheet.createRow(++groupRowIndex);
                 final XSSFCell groupCell = groupRow.createCell(1);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -3,6 +3,7 @@ package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
@@ -172,7 +173,7 @@ public class GapReportBuilder {
         boldTextCellStyle.setFont(boldFont);
         final XSSFCellStyle italicTextCellStyle = gapReportWorkbook.createCellStyle();
         italicTextCellStyle.setFont(italicFont);
-        italicTextCellStyle.setFillForegroundColor(new XSSFColor(GRAY));
+        italicTextCellStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.index);
 
         createDateLabelCell.setCellValue("Date Created");
         createDateLabelCell.setCellStyle(boldTextCellStyle);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.DefaultIndexedColorMap;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -161,6 +163,7 @@ public class GapReportBuilder {
     private final String CELL_STYLE_BOLD_TEXT = "boldText";
     private final String CELL_STYLE_NO_RECORDS = "italicText";
     private final String CELL_STYLE_REPORT_DETAILS_HEADER = "reportDetailsHeader";
+    private final String CELL_STYLE_DESIRED_INPUT = "desiredInput";
 
     /**
      * Create an Excel workbook for the Gap Report data.
@@ -269,12 +272,14 @@ public class GapReportBuilder {
                 }
             }
 
-            createReportDetailRow(reportSheet, gapReport.getGapReportRecords().get(i));
+            createReportDetailRow(reportSheet, gapReport.getGapReportRecords().get(i), cellStyleMap);
         }
 
         reportSheet.createFreezePane(0, 1);
 
-        applyAlternateRowConditionalFormatting(reportSheet);
+        final Set<CellRangeAddress> cellRangeAddresses = getRegions(reportSheet);
+
+        cellRangeAddresses.forEach(cellRangeAddress -> applyAlternateRowConditionalFormatting(reportSheet, cellRangeAddress));
 
         return gapReportWorkbook;
     }
@@ -316,7 +321,9 @@ public class GapReportBuilder {
      * @param data      A {@link java.util.Map} containing the column header and the value for a row from the
      *                  {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
-    private void createReportDetailRow(final XSSFSheet xssfSheet, final Map<String, Object> data) {
+    private void createReportDetailRow(final XSSFSheet xssfSheet,
+                                       final Map<String, Object> data,
+                                       final Map<String, XSSFCellStyle> cellStyleMap) {
         final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
         final Map<String, Short> desiredAndActualIndexMap = new HashMap<>();
 
@@ -338,18 +345,24 @@ public class GapReportBuilder {
                 detailCell.setCellValue(cellContent);
             }
 
-            // Add formulae
-            if (key.toLowerCase().startsWith("actual") || key.equals(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase())) {
+            // Add style specific to the "Desired" cell (i.e. the cell that requires user input).
+            if (key.toLowerCase().equals(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase())) {
+                desiredAndActualIndexMap.put(key, cellIndex);
+                detailCell.setCellStyle(cellStyleMap.get(CELL_STYLE_DESIRED_INPUT));
+            }
+
+            if (key.toLowerCase().startsWith("actual")) {
                 desiredAndActualIndexMap.put(key, cellIndex);
             }
 
+            // Add formulae
             if (key.matches("^[Dd]esired.*[1-5]")) {
                 desiredAndActualIndexMap.put(key, cellIndex);
                 final Cell desiredCountCell = row.getCell(desiredAndActualIndexMap.get(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase()));
                 detailCell.setCellFormula(String.format("IF(ISNUMBER(%1$s),FLOOR(%1$s/5,1),\"\")", desiredCountCell.getAddress().formatAsString()));
             }
 
-            if (key.matches("^([Dd]elta).*")) {
+            if (key.toLowerCase().startsWith("delta")) {
                 final Cell desiredCell = row.getCell(desiredAndActualIndexMap.get("desireddifficulty" + key.substring(key.length() - 1)));
                 final Cell actualCell = row.getCell(desiredAndActualIndexMap.get("actualdifficulty" + key.substring(key.length() - 1)));
                 detailCell.setCellFormula(String.format("IF(AND(ISNUMBER(%1$s),ISNUMBER(%2$s)),%1$s-%2$s,\"\")",
@@ -408,18 +421,47 @@ public class GapReportBuilder {
      * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that should have an alternating row color
      *                  applied
      */
-    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet) {
-        final CellRangeAddress[] allCells = {new CellRangeAddress(0,
-                xssfSheet.getLastRowNum(), 0,
-                xssfSheet.getRow(xssfSheet.getLastRowNum()).getLastCellNum() - 1)};
-
+    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet, CellRangeAddress region) {
         final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule alternatingRowRule = formatting.createConditionalFormattingRule("MOD(ROW(),2)=0");
         final XSSFPatternFormatting alternatingRowRulePatternFormatting = alternatingRowRule.createPatternFormatting();
-        final XSSFColor whitesmoke = new XSSFColor(new byte[]{(byte) 245, (byte) 245, (byte) 245}, null);
-        alternatingRowRulePatternFormatting.setFillBackgroundColor(whitesmoke);
+        final XSSFColor whiteSmokeColor = new XSSFColor(new byte[]{(byte) 245, (byte) 245, (byte) 245}, null);
+        alternatingRowRulePatternFormatting.setFillBackgroundColor(whiteSmokeColor);
 
-        formatting.addConditionalFormatting(allCells, alternatingRowRule);
+        formatting.addConditionalFormatting(new CellRangeAddress[]{region}, alternatingRowRule);
+    }
+
+    /**
+     * Get a set of {@link org.apache.poi.ss.util.CellRangeAddress}es that represent the various "regions" of the Gap
+     * Report spreadsheet.
+     *
+     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet}
+     * @return A {@link java.util.Set} of {@link org.apache.poi.ss.util.CellRangeAddress}es
+     */
+    private Set<CellRangeAddress> getRegions(final XSSFSheet xssfSheet) {
+
+        final int deltaLastCellIndex = xssfSheet.getRow(xssfSheet.getLastRowNum()).getLastCellNum() - 1;
+        final int deltaFirstCellIndex = deltaLastCellIndex - 5;
+        final int actualLastCellIndex = deltaFirstCellIndex - 1;
+        final int actualFirstCellIndex = actualLastCellIndex - 5;
+        final int desiredLastCellIndex = actualFirstCellIndex - 1;
+
+        // different because we want to leave the "Desired" column untouched.  The "Desired" column is the only column/
+        // cell that requires input; we want to be able to affect it separately (e.g. apply styles or other features).
+        // Thus we'll leave it out of the "Desired" cell region.
+        final int desiredFirstCellIndex = desiredLastCellIndex - 4;
+        final int groupsFirstCellIndex = 0;
+        final int groupsLastCellIndex = desiredFirstCellIndex - 2;
+
+        final CellRangeAddress groupsCellRangeAddress = new CellRangeAddress(0, xssfSheet.getLastRowNum(), groupsFirstCellIndex, groupsLastCellIndex);
+        final CellRangeAddress desiredCellRangeAddress = new CellRangeAddress(0, xssfSheet.getLastRowNum(), desiredFirstCellIndex, desiredLastCellIndex);
+        final CellRangeAddress actualCellRangeAddress = new CellRangeAddress(0, xssfSheet.getLastRowNum(), actualFirstCellIndex, actualLastCellIndex);
+        final CellRangeAddress deltaCellRangeAddress = new CellRangeAddress(0, xssfSheet.getLastRowNum(), deltaFirstCellIndex, deltaLastCellIndex);
+
+        return new HashSet<>(Arrays.asList(groupsCellRangeAddress,
+                desiredCellRangeAddress,
+                actualCellRangeAddress,
+                deltaCellRangeAddress));
     }
 
     /**
@@ -507,9 +549,15 @@ public class GapReportBuilder {
                 new XSSFColor(new byte[]{(byte) 70, (byte) 130, (byte) 180},
                         new DefaultIndexedColorMap()));
 
+        final XSSFCellStyle desiredInputCellStyle = xssfWorkbook.createCellStyle();
+        desiredInputCellStyle.setFont(boldFont);
+        desiredInputCellStyle.setFillForegroundColor(new XSSFColor(new byte[]{(byte) 255, (byte) 255, (byte) 224}, null));
+        desiredInputCellStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
         cellStyleMap.put(CELL_STYLE_BOLD_TEXT, boldTextCellStyle);
         cellStyleMap.put(CELL_STYLE_NO_RECORDS, noRecordCellStyle);
         cellStyleMap.put(CELL_STYLE_REPORT_DETAILS_HEADER, reportDetailsHeaderCellStyle);
+        cellStyleMap.put(CELL_STYLE_DESIRED_INPUT, desiredInputCellStyle);
 
         return cellStyleMap;
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -29,7 +29,99 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_RESOLUTION;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.DOK;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ENGLISH_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.HAS_UNRESOLVED_UPDATE_NEED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_REQUIRED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_AUTHOR;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_DIFFICULTY_QUINTILE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_NAME;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_TYPE_ID;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TEST_CATEGORY;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
+
 public class GapReportBuilder {
+    private static Map<String, String> columnNameToLabelMap = new HashMap<>();
+    static {
+        columnNameToLabelMap.put(INTENDED_GRADE.getColumnName(), "Intended Grade");
+        columnNameToLabelMap.put(SUBJECT.getColumnName(), "Subject");
+        columnNameToLabelMap.put(DOK.getColumnName(), "Depth of Knowledge");
+        columnNameToLabelMap.put(WORKFLOW_STATUS.getColumnName(), "Workflow Status");
+        columnNameToLabelMap.put(ITEM_TYPE.getColumnName(), "Type");
+        columnNameToLabelMap.put(ORGANIZATION_TYPE_ID.getColumnName(), "Organization Type ID");
+        columnNameToLabelMap.put(ORGANIZATION_NAME.getColumnName(), "Organization Name");
+        columnNameToLabelMap.put(ITEM_AUTHOR.getColumnName(), "Item Author");
+        columnNameToLabelMap.put(ITEM_DIFFICULTY_QUINTILE.getColumnName(), "Item Difficulty Quintile");
+        columnNameToLabelMap.put(TEST_CATEGORY.getColumnName(), "Test Category");
+        columnNameToLabelMap.put(PRIMARY_CLAIM.getColumnName(), "Primary Claim");
+        columnNameToLabelMap.put(PRIMARY_TARGET.getColumnName(), "Primary Target");
+        columnNameToLabelMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), "Primary Content Domain");
+        columnNameToLabelMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), "Primary Common Core Standard");
+        columnNameToLabelMap.put(SECONDARY_CLAIM.getColumnName(), "Secondary Claim");
+        columnNameToLabelMap.put(SECONDARY_TARGET.getColumnName(), "Secondary Target");
+        columnNameToLabelMap.put(SECONDARY_CONTENT_DOMAIN.getColumnName(), "Secondary Content Domain");
+        columnNameToLabelMap.put(SECONDARY_COMMON_CORE_STANDARD.getColumnName(), "Secondary Common Core Standard");
+        columnNameToLabelMap.put(TERTIARY_CLAIM.getColumnName(), "Tertiary Claim");
+        columnNameToLabelMap.put(TERTIARY_TARGET.getColumnName(), "Tertiary Target");
+        columnNameToLabelMap.put(TERTIARY_CONTENT_DOMAIN.getColumnName(), "Tertiary Content Domain");
+        columnNameToLabelMap.put(TERTIARY_COMMON_CORE_STANDARD.getColumnName(), "Tertiary Common Core Standard");
+        columnNameToLabelMap.put(QUATERNARY_CLAIM.getColumnName(), "Quaternary Claim");
+        columnNameToLabelMap.put(QUATERNARY_TARGET.getColumnName(),  "Quaternary Target");
+        columnNameToLabelMap.put(QUATERNARY_CONTENT_DOMAIN.getColumnName(), "Quaternary Content Domain");
+        columnNameToLabelMap.put(QUATERNARY_COMMON_CORE_STANDARD.getColumnName(), "Quaternary Common Core Standard");
+        columnNameToLabelMap.put(CONTENT_CHANGED_AFTER_OPERATIONAL.getColumnName(), "Has content changed after Operational");
+        columnNameToLabelMap.put(HAS_UNRESOLVED_UPDATE_NEED.getColumnName(), "Has unresolved update need");
+        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION.getColumnName(), "Current update need internal resolution");
+        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_RESOLUTION.getColumnName(), "Current update need resolution");
+        columnNameToLabelMap.put(ENGLISH_GLOSSARY_PROVIDED.getColumnName(), "Is English Glossary Provided");
+        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_PROVIDED.getColumnName(), "Is Illustrated Glossary Provided");
+        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_REQUIRED.getColumnName(), "Is Illustrated Glossary Required");
+        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_PROVIDED.getColumnName(), "Is Translated Glossary Provided");
+        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_REQUIRED.getColumnName(), "Is Illustrated Glossary Required");
+        columnNameToLabelMap.put("desired_difficulty_count", "Desired");
+        columnNameToLabelMap.put("desired_difficulty_1", "Desired Difficulty 1");
+        columnNameToLabelMap.put("desired_difficulty_2", "Desired Difficulty 2");
+        columnNameToLabelMap.put("desired_difficulty_3", "Desired Difficulty 3");
+        columnNameToLabelMap.put("desired_difficulty_4", "Desired Difficulty 4");
+        columnNameToLabelMap.put("desired_difficulty_5", "Desired Difficulty 5");
+        columnNameToLabelMap.put("actual_difficulty_count", "Actual");
+        columnNameToLabelMap.put("actual_difficulty_1", "Actual Difficulty 1");
+        columnNameToLabelMap.put("actual_difficulty_2", "Actual Difficulty 2");
+        columnNameToLabelMap.put("actual_difficulty_3", "Actual Difficulty 3");
+        columnNameToLabelMap.put("actual_difficulty_4", "Actual Difficulty 4");
+        columnNameToLabelMap.put("actual_difficulty_5", "Actual Difficulty 5");
+        columnNameToLabelMap.put("delta_difficulty_count", "Delta");
+        columnNameToLabelMap.put("delta_difficulty_1", "Delta Difficulty 1");
+        columnNameToLabelMap.put("delta_difficulty_2", "Delta Difficulty 2");
+        columnNameToLabelMap.put("delta_difficulty_3", "Delta Difficulty 3");
+        columnNameToLabelMap.put("delta_difficulty_4", "Delta Difficulty 4");
+        columnNameToLabelMap.put("delta_difficulty_5", "Delta Difficulty 5");
+    }
 
     public void getReport(final GapReport gapReport) throws IOException {
         final Map<String, Short> difficultyQuintileColumnIndices = new HashMap<>();
@@ -76,7 +168,7 @@ public class GapReportBuilder {
             for (final SearchFilter filter : gapReport.getFilters()) {
                 if (filtersHeaderRow.getLastCellNum() == 1) {
                     final XSSFCell firstFilterLabelCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    firstFilterLabelCell.setCellValue(filter.getFilterProperty().getProperty());
+                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getColumnName()));
 
                     final List<String> filterValues = getFilterValues(filter);
 
@@ -95,7 +187,7 @@ public class GapReportBuilder {
                     final List<String> filterValues = getFilterValues(filter);
                     final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
                     XSSFCell filterLabelCell = filterRow.createCell(1);
-                    filterLabelCell.setCellValue(filter.getFilterProperty().getProperty());
+                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getColumnName()));
 
                     int subsequentFilterValuesRowIndex = filterRow.getRowNum();
                     for (int i = 0; i < filterValues.size(); i++) {
@@ -153,7 +245,7 @@ public class GapReportBuilder {
                     }
 
                     final XSSFCell headerCell = headerRow.createCell(cellIndex);
-                    headerCell.setCellValue(headerText);
+                    headerCell.setCellValue(columnNameToLabelMap.get(headerText));
                     headerCell.setCellStyle(boldTextCellStyle);
 
                     if (headerText.toLowerCase().matches("(actual|desired)(.+)")) {

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -1,0 +1,224 @@
+package org.opentestsystem.ap.imrt.iss.model.reports.gap;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.BooleanFlagSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.ContainsSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.DateRangeSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.DaysBetweenSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.IdMatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.IntegerRangeSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+
+import java.awt.Color;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class GapReportBuilder {
+
+    public void getReport(final GapReport gapReport) throws IOException {
+        final Map<String, Short> difficultyQuintileColumnIndices = new HashMap<>();
+
+        final XSSFWorkbook gapReportWorkbook = new XSSFWorkbook();
+        gapReportWorkbook.getCellStyleAt(0).getFont().setFontHeightInPoints((short) 12);
+
+        final XSSFFont boldFont = gapReportWorkbook.createFont();
+        boldFont.setBold(true);
+        boldFont.setFontName(gapReportWorkbook.getCellStyleAt(0).getFont().getFontName());
+        boldFont.setFontHeight(gapReportWorkbook.getCellStyleAt(0).getFont().getFontHeight());
+        final XSSFFont italicFont = gapReportWorkbook.createFont();
+        italicFont.setItalic(true);
+        italicFont.setFontName(gapReportWorkbook.getCellStyleAt(0).getFont().getFontName());
+        italicFont.setColor(new XSSFColor(Color.GRAY));
+
+        // -------------------------------------------------------------------------------------------------------------
+        // REPORT PARAMETERS SHEET
+        // -------------------------------------------------------------------------------------------------------------
+        final XSSFSheet reportParametersSheet = gapReportWorkbook.createSheet("Report Parameters");
+
+        // Add date row
+        final XSSFRow createdDateRow = reportParametersSheet.createRow(0);
+        final XSSFCell createDateLabelCell = createdDateRow.createCell(0);
+        final XSSFCell createdDateCell = createdDateRow.createCell(1);
+
+        final XSSFCellStyle boldTextCellStyle = gapReportWorkbook.createCellStyle();
+        boldTextCellStyle.setFont(boldFont);
+        final XSSFCellStyle italicTextCellStyle = gapReportWorkbook.createCellStyle();
+        italicTextCellStyle.setFont(italicFont);
+        italicTextCellStyle.setFillForegroundColor(new XSSFColor(Color.GRAY));
+
+        createDateLabelCell.setCellValue("Date Created");
+        createDateLabelCell.setCellStyle(boldTextCellStyle);
+        createdDateCell.setCellValue(Date.from(gapReport.getCreatedDate()).toString());
+
+        // Add search filters
+        final XSSFRow filtersHeaderRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
+        final XSSFCell filtersHeaderLabelCell = filtersHeaderRow.createCell(0);
+        filtersHeaderLabelCell.setCellValue("Filters");
+        filtersHeaderLabelCell.setCellStyle(boldTextCellStyle);
+
+        if (!gapReport.getFilters().isEmpty()) {
+            for (final SearchFilter filter : gapReport.getFilters()) {
+                if (filtersHeaderRow.getLastCellNum() == 1) {
+                    final XSSFCell firstFilterLabelCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                    firstFilterLabelCell.setCellValue(filter.getFilterProperty().getProperty());
+
+                    final List<String> filterValues = getFilterValues(filter);
+
+                    int subsequentFilterValuesRowIndex = filtersHeaderRow.getRowNum();
+                    for (int i = 0; i < filterValues.size(); i++) {
+                        if (i == 0) {
+                            final XSSFCell firstFilterValueCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                            firstFilterValueCell.setCellValue(filterValues.get(0));
+                        } else {
+                            final XSSFRow filterValueRow = reportParametersSheet.createRow(++subsequentFilterValuesRowIndex);
+                            final XSSFCell filterValueCell = filterValueRow.createCell(2);
+                            filterValueCell.setCellValue(filterValues.get(i));
+                        }
+                    }
+                } else {
+                    final List<String> filterValues = getFilterValues(filter);
+                    final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
+                    XSSFCell filterLabelCell = filterRow.createCell(1);
+                    filterLabelCell.setCellValue(filter.getFilterProperty().getProperty());
+
+                    int subsequentFilterValuesRowIndex = filterRow.getRowNum();
+                    for (int i = 0; i < filterValues.size(); i++) {
+                        if (i == 0) {
+                            final XSSFCell firstFilterValueCell = filterRow.createCell(2);
+                            firstFilterValueCell.setCellValue(filterValues.get(0));
+                        } else {
+                            final XSSFRow filterValueRow = reportParametersSheet.createRow(++subsequentFilterValuesRowIndex);
+                            final XSSFCell filterValueCell = filterValueRow.createCell(2);
+                            filterValueCell.setCellValue(filterValues.get(i));
+                        }
+                    }
+                }
+            }
+        } else {
+            // add a row to indicate no filters were provided
+            filtersHeaderLabelCell.setCellValue("No search filters provided");
+            filtersHeaderLabelCell.setCellStyle(italicTextCellStyle);
+        }
+
+        int groupRowIndex = reportParametersSheet.getLastRowNum() + 1;
+        final XSSFRow groupsHeaderRow = reportParametersSheet.createRow(groupRowIndex);
+        final XSSFCell groupsHeaderCell = groupsHeaderRow.createCell(0);
+        groupsHeaderCell.setCellValue("Groups");
+        groupsHeaderCell.setCellStyle(boldTextCellStyle);
+
+        for (final SearchProperty group : gapReport.getGroupFilters()) {
+            if (groupsHeaderRow.getLastCellNum() == 1) {
+                final XSSFCell firstGroupValueCell = groupsHeaderRow.createCell(groupsHeaderRow.getLastCellNum());
+                firstGroupValueCell.setCellValue(group.getProperty());
+            } else {
+                final XSSFRow groupRow = reportParametersSheet.createRow(++groupRowIndex);
+                final XSSFCell groupCell = groupRow.createCell(1);
+                groupCell.setCellValue(group.getProperty());
+            }
+        }
+
+        reportParametersSheet.autoSizeColumn(0);
+        reportParametersSheet.autoSizeColumn(1);
+        reportParametersSheet.autoSizeColumn(2);
+
+        // -------------------------------------------------------------------------------------------------------------
+        // REPORT DETAILS SHEET
+        // -------------------------------------------------------------------------------------------------------------
+        final XSSFSheet reportSheet = gapReportWorkbook.createSheet("Report");
+
+        for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
+            if (i == 0) {
+                final XSSFRow headerRow = reportSheet.createRow(0);
+                // TODO:  Get "english" labels for headers
+                for (final String headerText : gapReport.getGapReportRecords().get(i).keySet()) {
+                    short cellIndex = headerRow.getLastCellNum();
+                    if (cellIndex < 0) {
+                        cellIndex = 0;
+                    }
+
+                    final XSSFCell headerCell = headerRow.createCell(cellIndex);
+                    headerCell.setCellValue(headerText);
+                    headerCell.setCellStyle(boldTextCellStyle);
+
+                    if (headerText.toLowerCase().matches("(actual|desired)(.+)")) {
+                        difficultyQuintileColumnIndices.put(headerText, cellIndex);
+                    }
+                }
+
+                for (int c = 0; c < headerRow.getLastCellNum(); c++) {
+                    reportSheet.autoSizeColumn(c);
+                }
+            }
+
+            final XSSFRow detailRow = reportSheet.createRow(i + 1);
+            for (final Object value : gapReport.getGapReportRecords().get(i).values()) {
+                final String val = Optional.ofNullable(value).isPresent()
+                        ? value.toString()
+                        : StringUtils.EMPTY;
+                short cellIndex = detailRow.getLastCellNum();
+                if (cellIndex < 0) {
+                    cellIndex = 0;
+                }
+
+                final XSSFCell detailCell = detailRow.createCell(cellIndex);
+                detailCell.setCellValue(val);
+            }
+
+            // TODO: add formula (check requirements) something like [actual difficulty - desired difficulty]
+        }
+
+        // write file
+        final String excelFileName = "/Users/jeffjohnson/Desktop/test.xlsx";
+        final FileOutputStream fileOutputStream = new FileOutputStream(excelFileName);
+
+        gapReportWorkbook.write(fileOutputStream);
+        fileOutputStream.flush();
+        fileOutputStream.close();
+    }
+
+    private List<String> getFilterValues(final SearchFilter filter) {
+        List<String> searchFilterValues;
+
+        // No need for FormMatchSearchFilter; nothing with forms supports counts
+        if (filter instanceof BooleanFlagSearchFilter) {
+            searchFilterValues = Collections.singletonList(String.valueOf(((BooleanFlagSearchFilter) filter).getFlag()));
+        } else if (filter instanceof ContainsSearchFilter) {
+            searchFilterValues = ((ContainsSearchFilter) filter).getFilterValues();
+        } else if (filter instanceof DateRangeSearchFilter) {
+            final DateRangeSearchFilter dateRangeSearchFilter = (DateRangeSearchFilter) filter;
+            searchFilterValues = Arrays.asList(String.format("from: %s", dateRangeSearchFilter.getFrom()),
+                    String.format("to: %s", dateRangeSearchFilter.getTo()));
+        } else if (filter instanceof DaysBetweenSearchFilter) {
+            final DaysBetweenSearchFilter daysBetweenSearchFilter = (DaysBetweenSearchFilter) filter;
+            searchFilterValues = Arrays.asList(String.format("min: %d", daysBetweenSearchFilter.getMin()),
+                    String.format("max: %d", daysBetweenSearchFilter.getMax()));
+        } else if (filter instanceof IdMatchSearchFilter) {
+            searchFilterValues = ((IdMatchSearchFilter) filter).getFilterValues();
+        } else if (filter instanceof IntegerRangeSearchFilter) {
+            final IntegerRangeSearchFilter integerRangeSearchFilter = (IntegerRangeSearchFilter) filter;
+            searchFilterValues = Collections.emptyList(); // TODO:  set filter values
+        } else if (filter instanceof MatchSearchFilter) {
+            searchFilterValues = ((MatchSearchFilter) filter).getFilterValues();
+        } else {
+            searchFilterValues = Collections.emptyList();
+        }
+
+        return searchFilterValues;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -94,6 +94,9 @@ import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculat
 import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_THREE;
 import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_TWO;
 
+/**
+ * Build the Gap Report as an MS Excel file.
+ */
 @Component
 public class GapReportBuilder {
     // A map of the search filter fields and their display labels

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -22,12 +22,15 @@ import org.springframework.stereotype.Component;
 
 import java.awt.*;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
@@ -186,7 +189,7 @@ public class GapReportBuilder {
             for (final SearchFilter filter : gapReport.getFilters()) {
                 if (filtersHeaderRow.getLastCellNum() == 1) {
                     final XSSFCell firstFilterLabelCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty()));
+                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
 
                     final List<String> filterValues = getFilterValues(filter);
 
@@ -205,7 +208,7 @@ public class GapReportBuilder {
                     final List<String> filterValues = getFilterValues(filter);
                     final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
                     XSSFCell filterLabelCell = filterRow.createCell(1);
-                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty()));
+                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
 
                     int subsequentFilterValuesRowIndex = filterRow.getRowNum();
                     for (int i = 0; i < filterValues.size(); i++) {
@@ -254,47 +257,75 @@ public class GapReportBuilder {
 
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
-                final XSSFRow headerRow = reportSheet.createRow(0);
-                for (final String headerText : gapReport.getGapReportRecords().get(i).keySet()) {
-                    short cellIndex = headerRow.getLastCellNum();
-                    if (cellIndex < 0) {
-                        cellIndex = 0;
-                    }
+                createHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(), boldTextCellStyle);
 
-                    final XSSFCell headerCell = headerRow.createCell(cellIndex);
-                    headerCell.setCellValue(columnNameToLabelMap.get(headerText));
-                    headerCell.setCellStyle(boldTextCellStyle);
-                }
-
-                for (int c = 0; c < headerRow.getLastCellNum(); c++) {
+                for (int c = 0; c < reportSheet.getRow(0).getLastCellNum(); c++) {
                     reportSheet.autoSizeColumn(c);
                 }
             }
 
-            final XSSFRow detailRow = reportSheet.createRow(i + 1);
-            for (final Object value : gapReport.getGapReportRecords().get(i).values()) {
-                final String val = Optional.ofNullable(value).isPresent()
-                        ? value.toString()
-                        : StringUtils.EMPTY;
-                short cellIndex = detailRow.getLastCellNum();
-                if (cellIndex < 0) {
-                    cellIndex = 0;
-                }
-
-                final XSSFCell detailCell = detailRow.createCell(cellIndex);
-                if (NumberUtils.isCreatable(val)) {
-                    detailCell.setCellValue(Double.parseDouble(val));
-                } else {
-                    detailCell.setCellValue(val);
-                }
-            }
-
-            // TODO: add formula (check requirements) something like [actual difficulty - desired difficulty]
+            createRow(reportSheet, gapReport.getGapReportRecords().get(i).values());
         }
+
+        // TODO: add formula (check requirements) something like [actual difficulty - desired difficulty]
 
         return gapReportWorkbook;
     }
 
+    /**
+     *
+     * @param xssfSheet
+     * @param headers
+     * @param cellStyle
+     */
+    private void createHeaderRow(final XSSFSheet xssfSheet, final Set<String> headers, final XSSFCellStyle cellStyle) {
+        final XSSFRow row = xssfSheet.createRow(0);
+
+        headers.forEach(h -> {
+            short cellIndex = row.getLastCellNum();
+            if (cellIndex < 0) {
+                cellIndex = 0;
+            }
+
+            final XSSFCell headerCell = row.createCell(cellIndex);
+            headerCell.setCellValue(columnNameToLabelMap.get(h));
+            headerCell.setCellStyle(cellStyle);
+
+            xssfSheet.autoSizeColumn(cellIndex);
+        });
+    }
+
+    /**
+     *
+     * @param xssfSheet
+     * @param data
+     */
+    private void createRow(final XSSFSheet xssfSheet, final Collection<Object> data) {
+        final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
+        data.forEach(recordValue -> {
+            final String val = Optional.ofNullable(recordValue).isPresent()
+                    ? recordValue.toString()
+                    : StringUtils.EMPTY;
+
+            short cellIndex = row.getLastCellNum();
+            if (cellIndex < 0) {
+                cellIndex = 0;
+            }
+
+            final XSSFCell detailCell = row.createCell(cellIndex);
+            if (NumberUtils.isCreatable(val)) {
+                detailCell.setCellValue(Double.parseDouble(val));
+            } else {
+                detailCell.setCellValue(val);
+            }
+        });
+    }
+
+    /**
+     *
+     * @param filter
+     * @return
+     */
     private List<String> getFilterValues(final SearchFilter filter) {
         List<String> searchFilterValues;
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
@@ -17,6 +18,7 @@ import org.opentestsystem.ap.imrt.iss.model.IdMatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.IntegerRangeSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.springframework.stereotype.Component;
 
 import java.awt.Color;
 import java.io.FileOutputStream;
@@ -65,6 +67,7 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATE
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
 
+@Component
 public class GapReportBuilder {
     private static Map<String, String> columnNameToLabelMap = new HashMap<>();
     static {
@@ -123,9 +126,7 @@ public class GapReportBuilder {
         columnNameToLabelMap.put("delta_difficulty_5", "Delta Difficulty 5");
     }
 
-    public void getReport(final GapReport gapReport) throws IOException {
-        final Map<String, Short> difficultyQuintileColumnIndices = new HashMap<>();
-
+    public XSSFWorkbook getReport(final GapReport gapReport) {
         final XSSFWorkbook gapReportWorkbook = new XSSFWorkbook();
         gapReportWorkbook.getCellStyleAt(0).getFont().setFontHeightInPoints((short) 12);
 
@@ -237,7 +238,6 @@ public class GapReportBuilder {
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
                 final XSSFRow headerRow = reportSheet.createRow(0);
-                // TODO:  Get "english" labels for headers
                 for (final String headerText : gapReport.getGapReportRecords().get(i).keySet()) {
                     short cellIndex = headerRow.getLastCellNum();
                     if (cellIndex < 0) {
@@ -247,10 +247,6 @@ public class GapReportBuilder {
                     final XSSFCell headerCell = headerRow.createCell(cellIndex);
                     headerCell.setCellValue(columnNameToLabelMap.get(headerText));
                     headerCell.setCellStyle(boldTextCellStyle);
-
-                    if (headerText.toLowerCase().matches("(actual|desired)(.+)")) {
-                        difficultyQuintileColumnIndices.put(headerText, cellIndex);
-                    }
                 }
 
                 for (int c = 0; c < headerRow.getLastCellNum(); c++) {
@@ -269,19 +265,17 @@ public class GapReportBuilder {
                 }
 
                 final XSSFCell detailCell = detailRow.createCell(cellIndex);
-                detailCell.setCellValue(val);
+                if (NumberUtils.isCreatable(val)) {
+                    detailCell.setCellValue(Double.parseDouble(val));
+                } else {
+                    detailCell.setCellValue(val);
+                }
             }
 
             // TODO: add formula (check requirements) something like [actual difficulty - desired difficulty]
         }
 
-        // write file
-        final String excelFileName = "/Users/jeffjohnson/Desktop/test.xlsx";
-        final FileOutputStream fileOutputStream = new FileOutputStream(excelFileName);
-
-        gapReportWorkbook.write(fileOutputStream);
-        fileOutputStream.flush();
-        fileOutputStream.close();
+        return gapReportWorkbook;
     }
 
     private List<String> getFilterValues(final SearchFilter filter) {

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -12,6 +12,7 @@ import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.poi.xssf.usermodel.XSSFConditionalFormattingRule;
 import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFFontFormatting;
 import org.apache.poi.xssf.usermodel.XSSFPatternFormatting;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -97,6 +98,7 @@ import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculat
 public class GapReportBuilder {
     // A map of the search filter fields and their display labels
     private static Map<String, String> columnNameToLabelMap = new HashMap<>();
+
     static {
         columnNameToLabelMap.put(INTENDED_GRADE.getProperty().toLowerCase(), "Intended Grade");
         columnNameToLabelMap.put(SUBJECT.getProperty().toLowerCase(), "Subject");
@@ -260,6 +262,8 @@ public class GapReportBuilder {
 
         reportSheet.createFreezePane(0, 1);
 
+        applyAlternateRowConditionalFormatting(reportSheet);
+
         return gapReportWorkbook;
     }
 
@@ -269,7 +273,7 @@ public class GapReportBuilder {
      * {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      *
      * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
-     * @param headers A {@link java.util.Set} containin all the column header labels
+     * @param headers   A {@link java.util.Set} containin all the column header labels
      * @param cellStyle The {@link org.apache.poi.xssf.usermodel.XSSFCellStyle} to apply to each header cell
      */
     private void createReportHeaderRow(final XSSFSheet xssfSheet,
@@ -297,8 +301,8 @@ public class GapReportBuilder {
      * details {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      *
      * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
-     * @param data A {@link java.util.Map} containing the column header and the value for a row from the
-     *             {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
+     * @param data      A {@link java.util.Map} containing the column header and the value for a row from the
+     *                  {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
     private void createReportDetailRow(final XSSFSheet xssfSheet, final Map<String, Object> data) {
         final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
@@ -334,8 +338,8 @@ public class GapReportBuilder {
                         actualCell.getAddress(),
                         desiredCell.getAddress()));
 
-                // Add conditional formatting
-                applyConditionalFormattingRules(xssfSheet, detailCell);
+                // Add conditional formatting to highlight cells based on the result of actual - desired
+                applyActualMinusDesiredCalculationConditionalFormattingRules(xssfSheet, detailCell);
             }
         });
     }
@@ -343,20 +347,23 @@ public class GapReportBuilder {
     /**
      * Add conditional formatting to the "Delta" columns of the report {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      * The conditional format will:
-     *
+     * <p>
      * -- Change the background color of the "Delta" cell to red if the value is negative
      * -- Change the background color of the "Delta" cell to green if the value is 0 or positive
      *
-     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param xssfSheet  The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
      * @param detailCell The {@link org.apache.poi.xssf.usermodel.XSSFCell} for one of the "Delta" columns
      */
-    private void applyConditionalFormattingRules(final XSSFSheet xssfSheet, final XSSFCell detailCell) {
+    private void applyActualMinusDesiredCalculationConditionalFormattingRules(final XSSFSheet xssfSheet,
+                                                                              final XSSFCell detailCell) {
         final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule goodDataRule =
                 formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%1$s),%1$s>=0)",
                         detailCell.getAddress().formatAsString()));
         final XSSFPatternFormatting goodDataRulePatternFormatting = goodDataRule.createPatternFormatting();
         final XSSFColor goodDataBackgroundColor = new XSSFColor(new byte[]{(byte) 204, (byte) 255, (byte) 204}, null);
+        final XSSFFontFormatting goodDataRuleFontFormatting = goodDataRule.createFontFormatting();
+        goodDataRuleFontFormatting.setFontColorIndex(IndexedColors.GREEN.getIndex());
         goodDataRulePatternFormatting.setFillBackgroundColor(goodDataBackgroundColor);
 
         final XSSFConditionalFormattingRule badDataRule =
@@ -364,6 +371,9 @@ public class GapReportBuilder {
                         detailCell.getAddress().formatAsString()));
         final XSSFPatternFormatting badDataRulePatternFormatting = badDataRule.createPatternFormatting();
         final XSSFColor badDataBackgroundColor = new XSSFColor(new byte[]{(byte) 255, (byte) 204, (byte) 204}, null);
+        final XSSFFontFormatting badDataRuleFontFormatting = badDataRule.createFontFormatting();
+        badDataRuleFontFormatting.setFontColorIndex(IndexedColors.RED.getIndex());
+        badDataRuleFontFormatting.setFontStyle(true, true);
         badDataRulePatternFormatting.setFillBackgroundColor(badDataBackgroundColor);
 
         final CellRangeAddress[] cellRange = {
@@ -372,6 +382,26 @@ public class GapReportBuilder {
 
         formatting.addConditionalFormatting(cellRange, goodDataRule);
         formatting.addConditionalFormatting(cellRange, badDataRule);
+    }
+
+    /**
+     * Apply an alternating row color to a {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
+     *
+     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that should have an alternating row color
+     *                  applied
+     */
+    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet) {
+        final CellRangeAddress[] allCells = {new CellRangeAddress(0,
+                xssfSheet.getLastRowNum(), 0,
+                xssfSheet.getRow(xssfSheet.getLastRowNum()).getLastCellNum() - 1)};
+
+        final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
+        final XSSFConditionalFormattingRule alternatingRowRule = formatting.createConditionalFormattingRule("MOD(ROW(),2)=0");
+        final XSSFPatternFormatting alternatingRowRulePatternFormatting = alternatingRowRule.createPatternFormatting();
+        final XSSFColor whitesmoke = new XSSFColor(new byte[]{(byte) 245, (byte) 245, (byte) 245}, null);
+        alternatingRowRulePatternFormatting.setFillBackgroundColor(whitesmoke);
+
+        formatting.addConditionalFormatting(allCells, alternatingRowRule);
     }
 
     /**
@@ -438,7 +468,7 @@ public class GapReportBuilder {
 
         final XSSFFont reportHeaderFont = xssfWorkbook.createFont();
         reportHeaderFont.setBold(true);
-        reportHeaderFont.setFontHeightInPoints((short)16);
+        reportHeaderFont.setFontHeightInPoints((short) 16);
         reportHeaderFont.setColor(IndexedColors.GREY_80_PERCENT.index);
 
         final XSSFCellStyle boldTextCellStyle = xssfWorkbook.createCellStyle();
@@ -455,7 +485,7 @@ public class GapReportBuilder {
         reportDetailsHeaderCellStyle.setBorderLeft(BorderStyle.NONE);
         reportDetailsHeaderCellStyle.setBorderBottom(BorderStyle.THICK);
         reportDetailsHeaderCellStyle.setBorderColor(XSSFCellBorder.BorderSide.BOTTOM,
-                new XSSFColor(IndexedColors.CORNFLOWER_BLUE,
+                new XSSFColor(new byte[]{(byte) 70, (byte) 130, (byte) 180},
                         new DefaultIndexedColorMap()));
 
         cellStyleMap.put(CELL_STYLE_BOLD_TEXT, boldTextCellStyle);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -247,6 +247,15 @@ public class GapReportBuilder {
         // -------------------------------------------------------------------------------------------------------------
         final XSSFSheet reportSheet = gapReportWorkbook.createSheet("Report");
 
+        if (gapReport.getGapReportRecords().isEmpty()) {
+            final XSSFRow noRecordsRow = reportSheet.createRow(0);
+            final XSSFCell noRecordsCell = noRecordsRow.createCell(0);
+            noRecordsCell.setCellValue("No records were found for the provided filters.  Please review the filters, make changes to the specified filter values and try again.");
+            noRecordsCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
+
+            return gapReportWorkbook;
+        }
+
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
                 createReportHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
@@ -334,7 +343,7 @@ public class GapReportBuilder {
             if (key.matches("^[Dd]esired.*[1-5]")) {
                 desiredAndActualIndexMap.put(key, cellIndex);
                 final Cell desiredCountCell = row.getCell(desiredAndActualIndexMap.get(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase()));
-                detailCell.setCellFormula(String.format("IF(ISNUMBER(%1$s),FLOOR(%s/5,1),\"\")", desiredCountCell.getAddress().formatAsString()));
+                detailCell.setCellFormula(String.format("IF(ISNUMBER(%1$s),FLOOR(%1$s/5,1),\"\")", desiredCountCell.getAddress().formatAsString()));
             }
 
             if (key.matches("^([Dd]elta).*")) {
@@ -467,10 +476,10 @@ public class GapReportBuilder {
         boldFont.setFontName(fontName);
         boldFont.setFontHeight(fontHeight);
 
-        final XSSFFont italicFont = xssfWorkbook.createFont();
-        italicFont.setItalic(true);
-        italicFont.setFontName(fontName);
-        italicFont.setColor(IndexedColors.GREY_25_PERCENT.index);
+        final XSSFFont noRecordFont = xssfWorkbook.createFont();
+        noRecordFont.setItalic(true);
+        noRecordFont.setFontName(fontName);
+        noRecordFont.setColor(IndexedColors.GREY_50_PERCENT.index);
 
         final XSSFFont reportHeaderFont = xssfWorkbook.createFont();
         reportHeaderFont.setBold(true);
@@ -481,8 +490,7 @@ public class GapReportBuilder {
         boldTextCellStyle.setFont(boldFont);
 
         final XSSFCellStyle noRecordCellStyle = xssfWorkbook.createCellStyle();
-        noRecordCellStyle.setFont(italicFont);
-        noRecordCellStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.index);
+        noRecordCellStyle.setFont(noRecordFont);
 
         final XSSFCellStyle reportDetailsHeaderCellStyle = xssfWorkbook.createCellStyle();
         reportDetailsHeaderCellStyle.setFont(reportHeaderFont);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -2,6 +2,7 @@ package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
@@ -20,9 +21,8 @@ import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.springframework.stereotype.Component;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
@@ -264,10 +263,10 @@ public class GapReportBuilder {
                 }
             }
 
-            createRow(reportSheet, gapReport.getGapReportRecords().get(i).values());
+            createRow(reportSheet, gapReport.getGapReportRecords().get(i));
         }
 
-        // TODO: add formula (check requirements) something like [actual difficulty - desired difficulty]
+        reportSheet.createFreezePane(0, 1);
 
         return gapReportWorkbook;
     }
@@ -300,11 +299,13 @@ public class GapReportBuilder {
      * @param xssfSheet
      * @param data
      */
-    private void createRow(final XSSFSheet xssfSheet, final Collection<Object> data) {
+    private void createRow(final XSSFSheet xssfSheet, final Map<String, Object> data) {
         final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
-        data.forEach(recordValue -> {
-            final String val = Optional.ofNullable(recordValue).isPresent()
-                    ? recordValue.toString()
+        final Map<String, Short> desiredAndActualIndexMap = new HashMap<>();
+
+        data.forEach((key, value) -> {
+            final String val = Optional.ofNullable(value).isPresent()
+                    ? value.toString()
                     : StringUtils.EMPTY;
 
             short cellIndex = row.getLastCellNum();
@@ -317,6 +318,21 @@ public class GapReportBuilder {
                 detailCell.setCellValue(Double.parseDouble(val));
             } else {
                 detailCell.setCellValue(val);
+            }
+
+            // Add formulae
+            if (key.matches("^([Aa]ctual|[Dd]esired).+")) {
+                desiredAndActualIndexMap.put(key, cellIndex);
+            }
+
+            if (key.matches("^([Dd]elta).*")) {
+                final Cell desiredCell = row.getCell(desiredAndActualIndexMap.get("desireddifficulty" + key.substring(key.length() - 1)));
+                final Cell actualCell = row.getCell(desiredAndActualIndexMap.get("actualdifficulty" + key.substring(key.length() - 1)));
+                detailCell.setCellFormula(String.format("IF(AND(ISNUMBER(%s),ISNUMBER(%s)),%s-%s,\"\")",
+                        actualCell.getAddress(),
+                        desiredCell.getAddress(),
+                        actualCell.getAddress(),
+                        desiredCell.getAddress()));
             }
         });
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -421,12 +421,12 @@ public class GapReportBuilder {
      * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that should have an alternating row color
      *                  applied
      */
-    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet, CellRangeAddress region) {
+    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet, final CellRangeAddress region) {
         final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule alternatingRowRule = formatting.createConditionalFormattingRule("MOD(ROW(),2)=0");
         final XSSFPatternFormatting alternatingRowRulePatternFormatting = alternatingRowRule.createPatternFormatting();
-        final XSSFColor whiteSmokeColor = new XSSFColor(new byte[]{(byte) 245, (byte) 245, (byte) 245}, null);
-        alternatingRowRulePatternFormatting.setFillBackgroundColor(whiteSmokeColor);
+        final XSSFColor alternatingRowColor = new XSSFColor(new byte[]{(byte) 240, (byte) 248, (byte) 255}, null);
+        alternatingRowRulePatternFormatting.setFillBackgroundColor(alternatingRowColor);
 
         formatting.addConditionalFormatting(new CellRangeAddress[]{region}, alternatingRowRule);
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -173,7 +173,7 @@ public class GapReportBuilder {
      * @return An {@link org.apache.poi.xssf.usermodel.XSSFWorkbook} containing the report parameters and report details
      * from the {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
-    public XSSFWorkbook getReport(final GapReport gapReport) {
+    public XSSFWorkbook convertToReport(final GapReport gapReport) {
         final XSSFWorkbook gapReportWorkbook = new XSSFWorkbook();
         final Map<String, XSSFCellStyle> cellStyleMap = getStyles(gapReportWorkbook);
 
@@ -197,35 +197,7 @@ public class GapReportBuilder {
         filtersHeaderLabelCell.setCellValue("Filters");
         filtersHeaderLabelCell.setCellStyle(cellStyleMap.get(CELL_STYLE_BOLD_TEXT));
 
-        if (!gapReport.getFilters().isEmpty()) {
-            for (final SearchFilter filter : gapReport.getFilters()) {
-                final String joinedFilterValues = getFilterValues(filter).stream()
-                        .collect(Collectors.joining(", "));
-
-                // Put the first filter on the same row as the "Subjects" header, all other filters should be in the
-                // same column beneath the first.  That is, the fitler's name should be in column B and the joined
-                // filter values should be in column C.
-                if (filtersHeaderRow.getLastCellNum() == 1) {
-                    final XSSFCell filterNameCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
-
-                    final XSSFCell filterValueCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    filterValueCell.setCellValue(joinedFilterValues);
-                } else {
-                    final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
-                    final XSSFCell filterNameCell = filterRow.createCell(1);
-                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
-
-                    final XSSFCell filterValuesCell = filterRow.createCell(filterRow.getLastCellNum());
-                    filterValuesCell.setCellValue(joinedFilterValues);
-                }
-            }
-        } else {
-            // add a row to indicate no filters were provided
-            final XSSFCell noRecordsCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-            noRecordsCell.setCellValue("No search filters provided");
-            noRecordsCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
-        }
+        updateReportParametersSheetWithSearchFilters(gapReport, cellStyleMap, reportParametersSheet, filtersHeaderRow);
 
         // Add groups
         int groupRowIndex = reportParametersSheet.getLastRowNum() + 1;
@@ -264,7 +236,7 @@ public class GapReportBuilder {
 
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
-                createReportHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
+                updateReportWithHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
                         cellStyleMap.get(CELL_STYLE_REPORT_DETAILS_HEADER));
 
                 for (int c = 0; c < reportSheet.getRow(0).getLastCellNum(); c++) {
@@ -272,16 +244,63 @@ public class GapReportBuilder {
                 }
             }
 
-            createReportDetailRow(reportSheet, gapReport.getGapReportRecords().get(i), cellStyleMap);
+            updateReportWithDetailsRow(reportSheet, gapReport.getGapReportRecords().get(i), cellStyleMap);
         }
 
         reportSheet.createFreezePane(0, 1);
 
         final Set<CellRangeAddress> cellRangeAddresses = getRegions(reportSheet);
 
-        cellRangeAddresses.forEach(cellRangeAddress -> applyAlternateRowConditionalFormatting(reportSheet, cellRangeAddress));
+        cellRangeAddresses.forEach(cellRangeAddress -> updateReportWithAlternatingRowFormatting(reportSheet, cellRangeAddress));
 
         return gapReportWorkbook;
+    }
+
+    /**
+     * Add the collection of {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s used to generate this Gap
+     * Report to the Report Parameters {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
+     *
+     * @param gapReport The {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport} containing the data to
+     *                  display
+     * @param cellStyleMap The collection of {@link org.apache.poi.xssf.usermodel.XSSFCellStyle}s that can be applied to
+     *                     a {@link org.apache.poi.xssf.usermodel.XSSFCell}
+     * @param reportParametersSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} for the Report Parameters page
+     * @param filtersHeaderRow The first {@link org.apache.poi.xssf.usermodel.XSSFRow} of the "Filters" section of the
+     *                         Report Parameters sheet
+     */
+    private void updateReportParametersSheetWithSearchFilters(final GapReport gapReport,
+                                                              final Map<String, XSSFCellStyle> cellStyleMap,
+                                                              final XSSFSheet reportParametersSheet,
+                                                              final XSSFRow filtersHeaderRow) {
+        if (!gapReport.getFilters().isEmpty()) {
+            for (final SearchFilter filter : gapReport.getFilters()) {
+                final String joinedFilterValues = getFilterValues(filter).stream()
+                        .collect(Collectors.joining(", "));
+
+                // Put the first filter on the same row as the "Subjects" header, all other filters should be in the
+                // same column beneath the first.  That is, the filter's name should be in column B and the joined
+                // filter values should be in column C.
+                if (filtersHeaderRow.getLastCellNum() == 1) {
+                    final XSSFCell filterNameCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
+
+                    final XSSFCell filterValueCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                    filterValueCell.setCellValue(joinedFilterValues);
+                } else {
+                    final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
+                    final XSSFCell filterNameCell = filterRow.createCell(1);
+                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
+
+                    final XSSFCell filterValuesCell = filterRow.createCell(filterRow.getLastCellNum());
+                    filterValuesCell.setCellValue(joinedFilterValues);
+                }
+            }
+        } else {
+            // add a row to indicate no filters were provided
+            final XSSFCell noRecordsCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+            noRecordsCell.setCellValue("No search filters provided");
+            noRecordsCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
+        }
     }
 
     /**
@@ -289,14 +308,14 @@ public class GapReportBuilder {
      * columns contained in the report.  The row will be attached to the
      * {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      *
-     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param report The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
      * @param headers   A {@link java.util.Set} containin all the column header labels
      * @param cellStyle The {@link org.apache.poi.xssf.usermodel.XSSFCellStyle} to apply to each header cell
      */
-    private void createReportHeaderRow(final XSSFSheet xssfSheet,
-                                       final Set<String> headers,
-                                       final XSSFCellStyle cellStyle) {
-        final XSSFRow row = xssfSheet.createRow(0);
+    private void updateReportWithHeaderRow(final XSSFSheet report,
+                                           final Set<String> headers,
+                                           final XSSFCellStyle cellStyle) {
+        final XSSFRow row = report.createRow(0);
 
         headers.forEach(h -> {
             short cellIndex = row.getLastCellNum();
@@ -308,7 +327,7 @@ public class GapReportBuilder {
             headerCell.setCellValue(columnNameToLabelMap.get(h));
             headerCell.setCellStyle(cellStyle);
 
-            xssfSheet.autoSizeColumn(cellIndex);
+            report.autoSizeColumn(cellIndex);
         });
     }
 
@@ -317,14 +336,14 @@ public class GapReportBuilder {
      * {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}.  The row will be attached to the report
      * details {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      *
-     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param report The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
      * @param data      A {@link java.util.Map} containing the column header and the value for a row from the
      *                  {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
-    private void createReportDetailRow(final XSSFSheet xssfSheet,
-                                       final Map<String, Object> data,
-                                       final Map<String, XSSFCellStyle> cellStyleMap) {
-        final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
+    private void updateReportWithDetailsRow(final XSSFSheet report,
+                                            final Map<String, Object> data,
+                                            final Map<String, XSSFCellStyle> cellStyleMap) {
+        final XSSFRow row = report.createRow(report.getLastRowNum() + 1);
         final Map<String, Short> desiredAndActualIndexMap = new HashMap<>();
 
         data.forEach((key, value) -> {
@@ -351,17 +370,22 @@ public class GapReportBuilder {
                 detailCell.setCellStyle(cellStyleMap.get(CELL_STYLE_DESIRED_INPUT));
             }
 
+            // Keep track of the position of the "actual" cells.  The "actual" cells are used as part of the formula to
+            // calculate the delta between actual and desired number of items for a particular difficulty quintile.
             if (key.toLowerCase().startsWith("actual")) {
                 desiredAndActualIndexMap.put(key, cellIndex);
             }
 
-            // Add formulae
+            // Keep track of the other "Desired" cells (i.e. the Desired 1 through Desired 5) columns.  These cells are
+            // used as part of the formula to calculate the delta between actual and desired number of items for a
+            // particular difficulty quintile.
             if (key.matches("^[Dd]esired.*[1-5]")) {
                 desiredAndActualIndexMap.put(key, cellIndex);
                 final Cell desiredCountCell = row.getCell(desiredAndActualIndexMap.get(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase()));
                 detailCell.setCellFormula(String.format("IF(ISNUMBER(%1$s),FLOOR(%1$s/5,1),\"\")", desiredCountCell.getAddress().formatAsString()));
             }
 
+            // Create formulae in the "Delta" cells; the formula is Actual - Desired = Delta.
             if (key.toLowerCase().startsWith("delta")) {
                 final Cell desiredCell = row.getCell(desiredAndActualIndexMap.get("desireddifficulty" + key.substring(key.length() - 1)));
                 final Cell actualCell = row.getCell(desiredAndActualIndexMap.get("actualdifficulty" + key.substring(key.length() - 1)));
@@ -370,7 +394,7 @@ public class GapReportBuilder {
                         desiredCell.getAddress()));
 
                 // Add conditional formatting to highlight cells based on the result of actual - desired
-                applyActualMinusDesiredCalculationConditionalFormattingRules(xssfSheet, detailCell);
+                updateReportWithActualMinusDesiredCalculationConditionalFormattingRules(report, detailCell);
             }
         });
     }
@@ -382,12 +406,12 @@ public class GapReportBuilder {
      * -- Change the background color of the "Delta" cell to red if the value is negative
      * -- Change the background color of the "Delta" cell to green if the value is 0 or positive
      *
-     * @param xssfSheet  The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param report  The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
      * @param detailCell The {@link org.apache.poi.xssf.usermodel.XSSFCell} for one of the "Delta" columns
      */
-    private void applyActualMinusDesiredCalculationConditionalFormattingRules(final XSSFSheet xssfSheet,
-                                                                              final XSSFCell detailCell) {
-        final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
+    private void updateReportWithActualMinusDesiredCalculationConditionalFormattingRules(final XSSFSheet report,
+                                                                                         final XSSFCell detailCell) {
+        final XSSFSheetConditionalFormatting formatting = report.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule goodDataRule =
                 formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%1$s),%1$s>=0)",
                         detailCell.getAddress().formatAsString()));
@@ -418,11 +442,11 @@ public class GapReportBuilder {
     /**
      * Apply an alternating row color to a {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
      *
-     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that should have an alternating row color
+     * @param report The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that should have an alternating row color
      *                  applied
      */
-    private void applyAlternateRowConditionalFormatting(final XSSFSheet xssfSheet, final CellRangeAddress region) {
-        final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
+    private void updateReportWithAlternatingRowFormatting(final XSSFSheet report, final CellRangeAddress region) {
+        final XSSFSheetConditionalFormatting formatting = report.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule alternatingRowRule = formatting.createConditionalFormattingRule("MOD(ROW(),2)=0");
         final XSSFPatternFormatting alternatingRowRulePatternFormatting = alternatingRowRule.createPatternFormatting();
         final XSSFColor alternatingRowColor = new XSSFColor(new byte[]{(byte) 240, (byte) 248, (byte) 255}, null);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -449,7 +449,9 @@ public class GapReportBuilder {
             searchFilterValues = ((IdMatchSearchFilter) filter).getFilterValues();
         } else if (filter instanceof IntegerRangeSearchFilter) {
             final IntegerRangeSearchFilter integerRangeSearchFilter = (IntegerRangeSearchFilter) filter;
-            searchFilterValues = Collections.emptyList(); // TODO:  set filter values
+            searchFilterValues = Collections.singletonList(String.format("min = %d, max = %d",
+                    integerRangeSearchFilter.getMin(),
+                    integerRangeSearchFilter.getMax()));
         } else if (filter instanceof MatchSearchFilter) {
             searchFilterValues = ((MatchSearchFilter) filter).getFilterValues();
         } else {

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -2,15 +2,22 @@ package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.DefaultIndexedColorMap;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
+import org.apache.poi.xssf.usermodel.XSSFConditionalFormattingRule;
 import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFPatternFormatting;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFSheetConditionalFormatting;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.usermodel.extensions.XSSFCellBorder;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.BooleanFlagSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.ContainsSearchFilter;
@@ -31,7 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.awt.Color.GRAY;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_RESOLUTION;
@@ -146,18 +152,18 @@ public class GapReportBuilder {
         columnNameToLabelMap.put(DELTA_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "Delta Difficulty 5");
     }
 
+    private final String CELL_STYLE_BOLD_TEXT = "boldText";
+    private final String CELL_STYLE_NO_RECORDS = "italicText";
+    private final String CELL_STYLE_REPORT_DETAILS_HEADER = "reportDetailsHeader";
+
+    /**
+     * 
+     * @param gapReport
+     * @return
+     */
     public XSSFWorkbook getReport(final GapReport gapReport) {
         final XSSFWorkbook gapReportWorkbook = new XSSFWorkbook();
-        gapReportWorkbook.getCellStyleAt(0).getFont().setFontHeightInPoints((short) 12);
-
-        final XSSFFont boldFont = gapReportWorkbook.createFont();
-        boldFont.setBold(true);
-        boldFont.setFontName(gapReportWorkbook.getCellStyleAt(0).getFont().getFontName());
-        boldFont.setFontHeight(gapReportWorkbook.getCellStyleAt(0).getFont().getFontHeight());
-        final XSSFFont italicFont = gapReportWorkbook.createFont();
-        italicFont.setItalic(true);
-        italicFont.setFontName(gapReportWorkbook.getCellStyleAt(0).getFont().getFontName());
-        italicFont.setColor(new XSSFColor(GRAY));
+        final Map<String, XSSFCellStyle> cellStyleMap = getStyles(gapReportWorkbook);
 
         // -------------------------------------------------------------------------------------------------------------
         // REPORT PARAMETERS SHEET
@@ -169,21 +175,15 @@ public class GapReportBuilder {
         final XSSFCell createDateLabelCell = createdDateRow.createCell(0);
         final XSSFCell createdDateCell = createdDateRow.createCell(1);
 
-        final XSSFCellStyle boldTextCellStyle = gapReportWorkbook.createCellStyle();
-        boldTextCellStyle.setFont(boldFont);
-        final XSSFCellStyle italicTextCellStyle = gapReportWorkbook.createCellStyle();
-        italicTextCellStyle.setFont(italicFont);
-        italicTextCellStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.index);
-
         createDateLabelCell.setCellValue("Date Created");
-        createDateLabelCell.setCellStyle(boldTextCellStyle);
+        createDateLabelCell.setCellStyle(cellStyleMap.get(CELL_STYLE_BOLD_TEXT));
         createdDateCell.setCellValue(Date.from(gapReport.getCreatedDate()).toString());
 
         // Add search filters
         final XSSFRow filtersHeaderRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
         final XSSFCell filtersHeaderLabelCell = filtersHeaderRow.createCell(0);
         filtersHeaderLabelCell.setCellValue("Filters");
-        filtersHeaderLabelCell.setCellStyle(boldTextCellStyle);
+        filtersHeaderLabelCell.setCellStyle(cellStyleMap.get(CELL_STYLE_BOLD_TEXT));
 
         if (!gapReport.getFilters().isEmpty()) {
             for (final SearchFilter filter : gapReport.getFilters()) {
@@ -226,14 +226,14 @@ public class GapReportBuilder {
         } else {
             // add a row to indicate no filters were provided
             filtersHeaderLabelCell.setCellValue("No search filters provided");
-            filtersHeaderLabelCell.setCellStyle(italicTextCellStyle);
+            filtersHeaderLabelCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
         }
 
         int groupRowIndex = reportParametersSheet.getLastRowNum() + 1;
         final XSSFRow groupsHeaderRow = reportParametersSheet.createRow(groupRowIndex);
         final XSSFCell groupsHeaderCell = groupsHeaderRow.createCell(0);
         groupsHeaderCell.setCellValue("Groups");
-        groupsHeaderCell.setCellStyle(boldTextCellStyle);
+        groupsHeaderCell.setCellStyle(cellStyleMap.get(CELL_STYLE_BOLD_TEXT));
 
         for (final SearchProperty group : gapReport.getGroupFilters()) {
             if (groupsHeaderRow.getLastCellNum() == 1) {
@@ -257,7 +257,8 @@ public class GapReportBuilder {
 
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
-                createHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(), boldTextCellStyle);
+                createHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
+                        cellStyleMap.get(CELL_STYLE_REPORT_DETAILS_HEADER));
 
                 for (int c = 0; c < reportSheet.getRow(0).getLastCellNum(); c++) {
                     reportSheet.autoSizeColumn(c);
@@ -282,7 +283,7 @@ public class GapReportBuilder {
 
         headers.forEach(h -> {
             short cellIndex = row.getLastCellNum();
-            if (cellIndex < 0) {
+            if (cellIndex < 0) { // row.getLastCellNum() will return -1 if the row does not have any cells
                 cellIndex = 0;
             }
 
@@ -303,20 +304,21 @@ public class GapReportBuilder {
         final Map<String, Short> desiredAndActualIndexMap = new HashMap<>();
 
         data.forEach((key, value) -> {
-            final String val = Optional.ofNullable(value).isPresent()
-                    ? value.toString()
-                    : StringUtils.EMPTY;
-
             short cellIndex = row.getLastCellNum();
-            if (cellIndex < 0) {
+            if (cellIndex < 0) { // row.getLastCellNum() will return -1 if the row does not have any cells
                 cellIndex = 0;
             }
 
             final XSSFCell detailCell = row.createCell(cellIndex);
-            if (NumberUtils.isCreatable(val)) {
-                detailCell.setCellValue(Double.parseDouble(val));
+
+            // Add data to the cell
+            final String cellContent = Optional.ofNullable(value).isPresent()
+                    ? value.toString()
+                    : StringUtils.EMPTY;
+            if (NumberUtils.isCreatable(cellContent)) {
+                detailCell.setCellValue(Double.parseDouble(cellContent));
             } else {
-                detailCell.setCellValue(val);
+                detailCell.setCellValue(cellContent);
             }
 
             // Add formulae
@@ -332,8 +334,41 @@ public class GapReportBuilder {
                         desiredCell.getAddress(),
                         actualCell.getAddress(),
                         desiredCell.getAddress()));
+
+                // Add conditional formatting
+                applyConditionalFormattingRules(xssfSheet, detailCell);
             }
         });
+    }
+
+    /**
+     * @param xssfSheet
+     * @param detailCell
+     */
+    private void applyConditionalFormattingRules(final XSSFSheet xssfSheet, final XSSFCell detailCell) {
+        final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
+        final XSSFConditionalFormattingRule goodDataRule =
+                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%s),%s>=0)",
+                        detailCell.getAddress().formatAsString(),
+                        detailCell.getAddress().formatAsString()));
+        final XSSFPatternFormatting goodDataRulePatternFormatting = goodDataRule.createPatternFormatting();
+        final XSSFColor goodDataBackgroundColor = new XSSFColor(new byte[]{(byte) 204, (byte) 255, (byte) 204}, null);
+        goodDataRulePatternFormatting.setFillBackgroundColor(goodDataBackgroundColor);
+
+        final XSSFConditionalFormattingRule badDataRule =
+                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%s),%s<0)",
+                        detailCell.getAddress().formatAsString(),
+                        detailCell.getAddress().formatAsString()));
+        final XSSFPatternFormatting badDataRulePatternFormatting = badDataRule.createPatternFormatting();
+        final XSSFColor badDataBackgroundColor = new XSSFColor(new byte[]{(byte) 255, (byte) 204, (byte) 204}, null);
+        badDataRulePatternFormatting.setFillBackgroundColor(badDataBackgroundColor);
+
+        final CellRangeAddress[] cellRange = {
+                CellRangeAddress.valueOf(detailCell.getAddress().formatAsString() + ":" + detailCell.getAddress().formatAsString())
+        };
+
+        formatting.addConditionalFormatting(cellRange, goodDataRule);
+        formatting.addConditionalFormatting(cellRange, badDataRule);
     }
 
     /**
@@ -368,5 +403,61 @@ public class GapReportBuilder {
         }
 
         return searchFilterValues;
+    }
+
+    /**
+     *
+     * @param xssfWorkbook
+     * @return
+     */
+    private Map<String, XSSFCellStyle> getStyles(final XSSFWorkbook xssfWorkbook) {
+        final Map<String, XSSFCellStyle> cellStyleMap = new HashMap<>();
+
+        xssfWorkbook.getCellStyleAt(0).getFont().setFontHeightInPoints((short) 12);
+        final String fontName = xssfWorkbook.getCellStyleAt(0).getFont().getFontName();
+        final short fontHeight = xssfWorkbook.getCellStyleAt(0).getFont().getFontHeight();
+
+        final XSSFFont boldFont = xssfWorkbook.createFont();
+        boldFont.setBold(true);
+        boldFont.setFontName(fontName);
+        boldFont.setFontHeight(fontHeight);
+
+        final XSSFFont italicFont = xssfWorkbook.createFont();
+        italicFont.setItalic(true);
+        italicFont.setFontName(fontName);
+        italicFont.setColor(IndexedColors.GREY_25_PERCENT.index);
+
+        final XSSFFont goodDataFont = xssfWorkbook.createFont();
+        goodDataFont.setFontName(fontName);
+        goodDataFont.setColor(IndexedColors.DARK_GREEN.index);
+
+        final XSSFFont badDataFont = xssfWorkbook.createFont();
+        badDataFont.setFontName(fontName);
+        badDataFont.setColor(IndexedColors.DARK_RED.index);
+        badDataFont.setBold(true);
+
+        final XSSFCellStyle boldTextCellStyle = xssfWorkbook.createCellStyle();
+        boldTextCellStyle.setFont(boldFont);
+
+        final XSSFCellStyle noRecordCellStyle = xssfWorkbook.createCellStyle();
+        noRecordCellStyle.setFont(italicFont);
+        noRecordCellStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.index);
+
+        final XSSFCellStyle reportDetailsHeaderCellStyle = xssfWorkbook.createCellStyle();
+        reportDetailsHeaderCellStyle.setFont(boldFont);
+        reportDetailsHeaderCellStyle.setBorderTop(BorderStyle.NONE);
+        reportDetailsHeaderCellStyle.setBorderRight(BorderStyle.NONE);
+        reportDetailsHeaderCellStyle.setBorderLeft(BorderStyle.NONE);
+        reportDetailsHeaderCellStyle.setBorderBottom(BorderStyle.THICK);
+        reportDetailsHeaderCellStyle.setBorderColor(XSSFCellBorder.BorderSide.BOTTOM,
+                new XSSFColor(IndexedColors.CORNFLOWER_BLUE,
+                        new DefaultIndexedColorMap()));
+        reportDetailsHeaderCellStyle.getFont().setFontHeightInPoints((short) 15);
+
+        cellStyleMap.put(CELL_STYLE_BOLD_TEXT, boldTextCellStyle);
+        cellStyleMap.put(CELL_STYLE_NO_RECORDS, noRecordCellStyle);
+        cellStyleMap.put(CELL_STYLE_REPORT_DETAILS_HEADER, reportDetailsHeaderCellStyle);
+
+        return cellStyleMap;
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -20,9 +20,7 @@ import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.springframework.stereotype.Component;
 
-import java.awt.Color;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -66,64 +64,83 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TEST_CATE
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_TWO;
 
 @Component
 public class GapReportBuilder {
     private static Map<String, String> columnNameToLabelMap = new HashMap<>();
+
     static {
-        columnNameToLabelMap.put(INTENDED_GRADE.getColumnName(), "Intended Grade");
-        columnNameToLabelMap.put(SUBJECT.getColumnName(), "Subject");
-        columnNameToLabelMap.put(DOK.getColumnName(), "Depth of Knowledge");
-        columnNameToLabelMap.put(WORKFLOW_STATUS.getColumnName(), "Workflow Status");
-        columnNameToLabelMap.put(ITEM_TYPE.getColumnName(), "Type");
-        columnNameToLabelMap.put(ORGANIZATION_TYPE_ID.getColumnName(), "Organization Type ID");
-        columnNameToLabelMap.put(ORGANIZATION_NAME.getColumnName(), "Organization Name");
-        columnNameToLabelMap.put(ITEM_AUTHOR.getColumnName(), "Item Author");
-        columnNameToLabelMap.put(ITEM_DIFFICULTY_QUINTILE.getColumnName(), "Item Difficulty Quintile");
-        columnNameToLabelMap.put(TEST_CATEGORY.getColumnName(), "Test Category");
-        columnNameToLabelMap.put(PRIMARY_CLAIM.getColumnName(), "Primary Claim");
-        columnNameToLabelMap.put(PRIMARY_TARGET.getColumnName(), "Primary Target");
-        columnNameToLabelMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), "Primary Content Domain");
-        columnNameToLabelMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), "Primary Common Core Standard");
-        columnNameToLabelMap.put(SECONDARY_CLAIM.getColumnName(), "Secondary Claim");
-        columnNameToLabelMap.put(SECONDARY_TARGET.getColumnName(), "Secondary Target");
-        columnNameToLabelMap.put(SECONDARY_CONTENT_DOMAIN.getColumnName(), "Secondary Content Domain");
-        columnNameToLabelMap.put(SECONDARY_COMMON_CORE_STANDARD.getColumnName(), "Secondary Common Core Standard");
-        columnNameToLabelMap.put(TERTIARY_CLAIM.getColumnName(), "Tertiary Claim");
-        columnNameToLabelMap.put(TERTIARY_TARGET.getColumnName(), "Tertiary Target");
-        columnNameToLabelMap.put(TERTIARY_CONTENT_DOMAIN.getColumnName(), "Tertiary Content Domain");
-        columnNameToLabelMap.put(TERTIARY_COMMON_CORE_STANDARD.getColumnName(), "Tertiary Common Core Standard");
-        columnNameToLabelMap.put(QUATERNARY_CLAIM.getColumnName(), "Quaternary Claim");
-        columnNameToLabelMap.put(QUATERNARY_TARGET.getColumnName(),  "Quaternary Target");
-        columnNameToLabelMap.put(QUATERNARY_CONTENT_DOMAIN.getColumnName(), "Quaternary Content Domain");
-        columnNameToLabelMap.put(QUATERNARY_COMMON_CORE_STANDARD.getColumnName(), "Quaternary Common Core Standard");
-        columnNameToLabelMap.put(CONTENT_CHANGED_AFTER_OPERATIONAL.getColumnName(), "Has content changed after Operational");
-        columnNameToLabelMap.put(HAS_UNRESOLVED_UPDATE_NEED.getColumnName(), "Has unresolved update need");
-        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION.getColumnName(), "Current update need internal resolution");
-        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_RESOLUTION.getColumnName(), "Current update need resolution");
-        columnNameToLabelMap.put(ENGLISH_GLOSSARY_PROVIDED.getColumnName(), "Is English Glossary Provided");
-        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_PROVIDED.getColumnName(), "Is Illustrated Glossary Provided");
-        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_REQUIRED.getColumnName(), "Is Illustrated Glossary Required");
-        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_PROVIDED.getColumnName(), "Is Translated Glossary Provided");
-        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_REQUIRED.getColumnName(), "Is Illustrated Glossary Required");
-        columnNameToLabelMap.put("desired_difficulty_count", "Desired");
-        columnNameToLabelMap.put("desired_difficulty_1", "Desired Difficulty 1");
-        columnNameToLabelMap.put("desired_difficulty_2", "Desired Difficulty 2");
-        columnNameToLabelMap.put("desired_difficulty_3", "Desired Difficulty 3");
-        columnNameToLabelMap.put("desired_difficulty_4", "Desired Difficulty 4");
-        columnNameToLabelMap.put("desired_difficulty_5", "Desired Difficulty 5");
-        columnNameToLabelMap.put("actual_difficulty_count", "Actual");
-        columnNameToLabelMap.put("actual_difficulty_1", "Actual Difficulty 1");
-        columnNameToLabelMap.put("actual_difficulty_2", "Actual Difficulty 2");
-        columnNameToLabelMap.put("actual_difficulty_3", "Actual Difficulty 3");
-        columnNameToLabelMap.put("actual_difficulty_4", "Actual Difficulty 4");
-        columnNameToLabelMap.put("actual_difficulty_5", "Actual Difficulty 5");
-        columnNameToLabelMap.put("delta_difficulty_count", "Delta");
-        columnNameToLabelMap.put("delta_difficulty_1", "Delta Difficulty 1");
-        columnNameToLabelMap.put("delta_difficulty_2", "Delta Difficulty 2");
-        columnNameToLabelMap.put("delta_difficulty_3", "Delta Difficulty 3");
-        columnNameToLabelMap.put("delta_difficulty_4", "Delta Difficulty 4");
-        columnNameToLabelMap.put("delta_difficulty_5", "Delta Difficulty 5");
+        columnNameToLabelMap.put(INTENDED_GRADE.getProperty().toLowerCase(), "Intended Grade");
+        columnNameToLabelMap.put(SUBJECT.getProperty().toLowerCase(), "Subject");
+        columnNameToLabelMap.put(DOK.getProperty().toLowerCase(), "Depth of Knowledge");
+        columnNameToLabelMap.put(WORKFLOW_STATUS.getProperty().toLowerCase(), "Workflow Status");
+        columnNameToLabelMap.put(ITEM_TYPE.getProperty().toLowerCase(), "Type");
+        columnNameToLabelMap.put(ORGANIZATION_TYPE_ID.getProperty().toLowerCase(), "Organization Type ID");
+        columnNameToLabelMap.put(ORGANIZATION_NAME.getProperty().toLowerCase(), "Organization Name");
+        columnNameToLabelMap.put(ITEM_AUTHOR.getProperty().toLowerCase(), "Item Author");
+        columnNameToLabelMap.put(ITEM_DIFFICULTY_QUINTILE.getProperty().toLowerCase(), "Item Difficulty Quintile");
+        columnNameToLabelMap.put(TEST_CATEGORY.getProperty().toLowerCase(), "Test Category");
+        columnNameToLabelMap.put(PRIMARY_CLAIM.getProperty().toLowerCase(), "Primary Claim");
+        columnNameToLabelMap.put(PRIMARY_TARGET.getProperty().toLowerCase(), "Primary Target");
+        columnNameToLabelMap.put(PRIMARY_CONTENT_DOMAIN.getProperty().toLowerCase(), "Primary Content Domain");
+        columnNameToLabelMap.put(PRIMARY_COMMON_CORE_STANDARD.getProperty().toLowerCase(), "Primary Common Core Standard");
+        columnNameToLabelMap.put(SECONDARY_CLAIM.getProperty().toLowerCase(), "Secondary Claim");
+        columnNameToLabelMap.put(SECONDARY_TARGET.getProperty().toLowerCase(), "Secondary Target");
+        columnNameToLabelMap.put(SECONDARY_CONTENT_DOMAIN.getProperty().toLowerCase(), "Secondary Content Domain");
+        columnNameToLabelMap.put(SECONDARY_COMMON_CORE_STANDARD.getProperty().toLowerCase(), "Secondary Common Core Standard");
+        columnNameToLabelMap.put(TERTIARY_CLAIM.getProperty().toLowerCase(), "Tertiary Claim");
+        columnNameToLabelMap.put(TERTIARY_TARGET.getProperty().toLowerCase(), "Tertiary Target");
+        columnNameToLabelMap.put(TERTIARY_CONTENT_DOMAIN.getProperty().toLowerCase(), "Tertiary Content Domain");
+        columnNameToLabelMap.put(TERTIARY_COMMON_CORE_STANDARD.getProperty().toLowerCase(), "Tertiary Common Core Standard");
+        columnNameToLabelMap.put(QUATERNARY_CLAIM.getProperty().toLowerCase(), "Quaternary Claim");
+        columnNameToLabelMap.put(QUATERNARY_TARGET.getProperty().toLowerCase(), "Quaternary Target");
+        columnNameToLabelMap.put(QUATERNARY_CONTENT_DOMAIN.getProperty().toLowerCase(), "Quaternary Content Domain");
+        columnNameToLabelMap.put(QUATERNARY_COMMON_CORE_STANDARD.getProperty().toLowerCase(), "Quaternary Common Core Standard");
+        columnNameToLabelMap.put(CONTENT_CHANGED_AFTER_OPERATIONAL.getProperty().toLowerCase(), "Has content changed after Operational");
+        columnNameToLabelMap.put(HAS_UNRESOLVED_UPDATE_NEED.getProperty().toLowerCase(), "Has unresolved update need");
+        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION.getProperty().toLowerCase(), "Current update need internal resolution");
+        columnNameToLabelMap.put(CURRENT_UPDATE_NEED_RESOLUTION.getProperty().toLowerCase(), "Current update need resolution");
+        columnNameToLabelMap.put(ENGLISH_GLOSSARY_PROVIDED.getProperty().toLowerCase(), "Is English Glossary Provided");
+        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_PROVIDED.getProperty().toLowerCase(), "Is Illustrated Glossary Provided");
+        columnNameToLabelMap.put(ILLUSTRATED_GLOSSARY_REQUIRED.getProperty().toLowerCase(), "Is Illustrated Glossary Required");
+        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_PROVIDED.getProperty().toLowerCase(), "Is Translated Glossary Provided");
+        columnNameToLabelMap.put(TRANSLATED_GLOSSARY_REQUIRED.getProperty().toLowerCase(), "Is Illustrated Glossary Required");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase(), "Desired");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_ONE.getFieldName().toLowerCase(), "Desired Difficulty 1");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_TWO.getFieldName().toLowerCase(), "Desired Difficulty 2");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_THREE.getFieldName().toLowerCase(), "Desired Difficulty 3");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_FOUR.getFieldName().toLowerCase(), "Desired Difficulty 4");
+        columnNameToLabelMap.put(DESIRED_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "Desired Difficulty 5");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase(), "Actual");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase(), "Actual Difficulty 1");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase(), "Actual Difficulty 2");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase(), "Actual Difficulty 3");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase(), "Actual Difficulty 4");
+        columnNameToLabelMap.put(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "Actual Difficulty 5");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_COUNT.getFieldName().toLowerCase(), "Delta");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_ONE.getFieldName().toLowerCase(), "Delta Difficulty 1");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_TWO.getFieldName().toLowerCase(), "Delta Difficulty 2");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_THREE.getFieldName().toLowerCase(), "Delta Difficulty 3");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_FOUR.getFieldName().toLowerCase(), "Delta Difficulty 4");
+        columnNameToLabelMap.put(DELTA_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "Delta Difficulty 5");
     }
 
     public XSSFWorkbook getReport(final GapReport gapReport) {
@@ -169,7 +186,7 @@ public class GapReportBuilder {
             for (final SearchFilter filter : gapReport.getFilters()) {
                 if (filtersHeaderRow.getLastCellNum() == 1) {
                     final XSSFCell firstFilterLabelCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getColumnName()));
+                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty()));
 
                     final List<String> filterValues = getFilterValues(filter);
 
@@ -188,7 +205,7 @@ public class GapReportBuilder {
                     final List<String> filterValues = getFilterValues(filter);
                     final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
                     XSSFCell filterLabelCell = filterRow.createCell(1);
-                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getColumnName()));
+                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty()));
 
                     int subsequentFilterValuesRowIndex = filterRow.getRowNum();
                     for (int i = 0; i < filterValues.size(); i++) {
@@ -222,7 +239,7 @@ public class GapReportBuilder {
             } else {
                 final XSSFRow groupRow = reportParametersSheet.createRow(++groupRowIndex);
                 final XSSFCell groupCell = groupRow.createCell(1);
-                groupCell.setCellValue(group.getProperty());
+                groupCell.setCellValue(columnNameToLabelMap.get(group.getProperty().toLowerCase()));
             }
         }
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -21,7 +21,6 @@ import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.springframework.stereotype.Component;
 
-import java.awt.Color;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -31,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.awt.Color.GRAY;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_RESOLUTION;
@@ -156,7 +156,7 @@ public class GapReportBuilder {
         final XSSFFont italicFont = gapReportWorkbook.createFont();
         italicFont.setItalic(true);
         italicFont.setFontName(gapReportWorkbook.getCellStyleAt(0).getFont().getFontName());
-        italicFont.setColor(new XSSFColor(Color.GRAY));
+        italicFont.setColor(new XSSFColor(GRAY));
 
         // -------------------------------------------------------------------------------------------------------------
         // REPORT PARAMETERS SHEET
@@ -172,7 +172,7 @@ public class GapReportBuilder {
         boldTextCellStyle.setFont(boldFont);
         final XSSFCellStyle italicTextCellStyle = gapReportWorkbook.createCellStyle();
         italicTextCellStyle.setFont(italicFont);
-        italicTextCellStyle.setFillForegroundColor(new XSSFColor(Color.GRAY));
+        italicTextCellStyle.setFillForegroundColor(new XSSFColor(GRAY));
 
         createDateLabelCell.setCellValue("Date Created");
         createDateLabelCell.setCellStyle(boldTextCellStyle);
@@ -272,7 +272,6 @@ public class GapReportBuilder {
     }
 
     /**
-     *
      * @param xssfSheet
      * @param headers
      * @param cellStyle
@@ -295,7 +294,6 @@ public class GapReportBuilder {
     }
 
     /**
-     *
      * @param xssfSheet
      * @param data
      */
@@ -338,7 +336,6 @@ public class GapReportBuilder {
     }
 
     /**
-     *
      * @param filter
      * @return
      */

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportBuilder.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
@@ -94,8 +95,8 @@ import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculat
 
 @Component
 public class GapReportBuilder {
+    // A map of the search filter fields and their display labels
     private static Map<String, String> columnNameToLabelMap = new HashMap<>();
-
     static {
         columnNameToLabelMap.put(INTENDED_GRADE.getProperty().toLowerCase(), "Intended Grade");
         columnNameToLabelMap.put(SUBJECT.getProperty().toLowerCase(), "Subject");
@@ -157,9 +158,12 @@ public class GapReportBuilder {
     private final String CELL_STYLE_REPORT_DETAILS_HEADER = "reportDetailsHeader";
 
     /**
-     * 
-     * @param gapReport
-     * @return
+     * Create an Excel workbook for the Gap Report data.
+     *
+     * @param gapReport The {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport} containing the data that
+     *                  should be displayed on the report.
+     * @return An {@link org.apache.poi.xssf.usermodel.XSSFWorkbook} containing the report parameters and report details
+     * from the {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
     public XSSFWorkbook getReport(final GapReport gapReport) {
         final XSSFWorkbook gapReportWorkbook = new XSSFWorkbook();
@@ -187,48 +191,35 @@ public class GapReportBuilder {
 
         if (!gapReport.getFilters().isEmpty()) {
             for (final SearchFilter filter : gapReport.getFilters()) {
+                final String joinedFilterValues = getFilterValues(filter).stream()
+                        .collect(Collectors.joining(", "));
+
+                // Put the first filter on the same row as the "Subjects" header, all other filters should be in the
+                // same column beneath the first.  That is, the fitler's name should be in column B and the joined
+                // filter values should be in column C.
                 if (filtersHeaderRow.getLastCellNum() == 1) {
-                    final XSSFCell firstFilterLabelCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                    firstFilterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
+                    final XSSFCell filterNameCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
 
-                    final List<String> filterValues = getFilterValues(filter);
-
-                    int subsequentFilterValuesRowIndex = filtersHeaderRow.getRowNum();
-                    for (int i = 0; i < filterValues.size(); i++) {
-                        if (i == 0) {
-                            final XSSFCell firstFilterValueCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
-                            firstFilterValueCell.setCellValue(filterValues.get(0));
-                        } else {
-                            final XSSFRow filterValueRow = reportParametersSheet.createRow(++subsequentFilterValuesRowIndex);
-                            final XSSFCell filterValueCell = filterValueRow.createCell(2);
-                            filterValueCell.setCellValue(filterValues.get(i));
-                        }
-                    }
+                    final XSSFCell filterValueCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+                    filterValueCell.setCellValue(joinedFilterValues);
                 } else {
-                    final List<String> filterValues = getFilterValues(filter);
                     final XSSFRow filterRow = reportParametersSheet.createRow(reportParametersSheet.getLastRowNum() + 1);
-                    XSSFCell filterLabelCell = filterRow.createCell(1);
-                    filterLabelCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
+                    final XSSFCell filterNameCell = filterRow.createCell(1);
+                    filterNameCell.setCellValue(columnNameToLabelMap.get(filter.getFilterProperty().getProperty().toLowerCase()));
 
-                    int subsequentFilterValuesRowIndex = filterRow.getRowNum();
-                    for (int i = 0; i < filterValues.size(); i++) {
-                        if (i == 0) {
-                            final XSSFCell firstFilterValueCell = filterRow.createCell(2);
-                            firstFilterValueCell.setCellValue(filterValues.get(0));
-                        } else {
-                            final XSSFRow filterValueRow = reportParametersSheet.createRow(++subsequentFilterValuesRowIndex);
-                            final XSSFCell filterValueCell = filterValueRow.createCell(2);
-                            filterValueCell.setCellValue(filterValues.get(i));
-                        }
-                    }
+                    final XSSFCell filterValuesCell = filterRow.createCell(filterRow.getLastCellNum());
+                    filterValuesCell.setCellValue(joinedFilterValues);
                 }
             }
         } else {
             // add a row to indicate no filters were provided
-            filtersHeaderLabelCell.setCellValue("No search filters provided");
-            filtersHeaderLabelCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
+            final XSSFCell noRecordsCell = filtersHeaderRow.createCell(filtersHeaderRow.getLastCellNum());
+            noRecordsCell.setCellValue("No search filters provided");
+            noRecordsCell.setCellStyle(cellStyleMap.get(CELL_STYLE_NO_RECORDS));
         }
 
+        // Add groups
         int groupRowIndex = reportParametersSheet.getLastRowNum() + 1;
         final XSSFRow groupsHeaderRow = reportParametersSheet.createRow(groupRowIndex);
         final XSSFCell groupsHeaderCell = groupsHeaderRow.createCell(0);
@@ -248,7 +239,6 @@ public class GapReportBuilder {
 
         reportParametersSheet.autoSizeColumn(0);
         reportParametersSheet.autoSizeColumn(1);
-        reportParametersSheet.autoSizeColumn(2);
 
         // -------------------------------------------------------------------------------------------------------------
         // REPORT DETAILS SHEET
@@ -257,7 +247,7 @@ public class GapReportBuilder {
 
         for (int i = 0; i < gapReport.getGapReportRecords().size(); i++) {
             if (i == 0) {
-                createHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
+                createReportHeaderRow(reportSheet, gapReport.getGapReportRecords().get(i).keySet(),
                         cellStyleMap.get(CELL_STYLE_REPORT_DETAILS_HEADER));
 
                 for (int c = 0; c < reportSheet.getRow(0).getLastCellNum(); c++) {
@@ -265,7 +255,7 @@ public class GapReportBuilder {
                 }
             }
 
-            createRow(reportSheet, gapReport.getGapReportRecords().get(i));
+            createReportDetailRow(reportSheet, gapReport.getGapReportRecords().get(i));
         }
 
         reportSheet.createFreezePane(0, 1);
@@ -274,11 +264,17 @@ public class GapReportBuilder {
     }
 
     /**
-     * @param xssfSheet
-     * @param headers
-     * @param cellStyle
+     * Create a header for the report {@link org.apache.poi.xssf.usermodel.XSSFSheet} containing the names of the
+     * columns contained in the report.  The row will be attached to the
+     * {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
+     *
+     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param headers A {@link java.util.Set} containin all the column header labels
+     * @param cellStyle The {@link org.apache.poi.xssf.usermodel.XSSFCellStyle} to apply to each header cell
      */
-    private void createHeaderRow(final XSSFSheet xssfSheet, final Set<String> headers, final XSSFCellStyle cellStyle) {
+    private void createReportHeaderRow(final XSSFSheet xssfSheet,
+                                       final Set<String> headers,
+                                       final XSSFCellStyle cellStyle) {
         final XSSFRow row = xssfSheet.createRow(0);
 
         headers.forEach(h -> {
@@ -296,10 +292,15 @@ public class GapReportBuilder {
     }
 
     /**
-     * @param xssfSheet
-     * @param data
+     * Create an {@link org.apache.poi.xssf.usermodel.XSSFRow} containing the details of a record from the
+     * {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}.  The row will be attached to the report
+     * details {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
+     *
+     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param data A {@link java.util.Map} containing the column header and the value for a row from the
+     *             {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
-    private void createRow(final XSSFSheet xssfSheet, final Map<String, Object> data) {
+    private void createReportDetailRow(final XSSFSheet xssfSheet, final Map<String, Object> data) {
         final XSSFRow row = xssfSheet.createRow(xssfSheet.getLastRowNum() + 1);
         final Map<String, Short> desiredAndActualIndexMap = new HashMap<>();
 
@@ -329,9 +330,7 @@ public class GapReportBuilder {
             if (key.matches("^([Dd]elta).*")) {
                 final Cell desiredCell = row.getCell(desiredAndActualIndexMap.get("desireddifficulty" + key.substring(key.length() - 1)));
                 final Cell actualCell = row.getCell(desiredAndActualIndexMap.get("actualdifficulty" + key.substring(key.length() - 1)));
-                detailCell.setCellFormula(String.format("IF(AND(ISNUMBER(%s),ISNUMBER(%s)),%s-%s,\"\")",
-                        actualCell.getAddress(),
-                        desiredCell.getAddress(),
+                detailCell.setCellFormula(String.format("IF(AND(ISNUMBER(%1$s),ISNUMBER(%2$s)),%1$s-%2$s,\"\")",
                         actualCell.getAddress(),
                         desiredCell.getAddress()));
 
@@ -342,22 +341,26 @@ public class GapReportBuilder {
     }
 
     /**
-     * @param xssfSheet
-     * @param detailCell
+     * Add conditional formatting to the "Delta" columns of the report {@link org.apache.poi.xssf.usermodel.XSSFSheet}.
+     * The conditional format will:
+     *
+     * -- Change the background color of the "Delta" cell to red if the value is negative
+     * -- Change the background color of the "Delta" cell to green if the value is 0 or positive
+     *
+     * @param xssfSheet The {@link org.apache.poi.xssf.usermodel.XSSFSheet} that will contain the report data
+     * @param detailCell The {@link org.apache.poi.xssf.usermodel.XSSFCell} for one of the "Delta" columns
      */
     private void applyConditionalFormattingRules(final XSSFSheet xssfSheet, final XSSFCell detailCell) {
         final XSSFSheetConditionalFormatting formatting = xssfSheet.getSheetConditionalFormatting();
         final XSSFConditionalFormattingRule goodDataRule =
-                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%s),%s>=0)",
-                        detailCell.getAddress().formatAsString(),
+                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%1$s),%1$s>=0)",
                         detailCell.getAddress().formatAsString()));
         final XSSFPatternFormatting goodDataRulePatternFormatting = goodDataRule.createPatternFormatting();
         final XSSFColor goodDataBackgroundColor = new XSSFColor(new byte[]{(byte) 204, (byte) 255, (byte) 204}, null);
         goodDataRulePatternFormatting.setFillBackgroundColor(goodDataBackgroundColor);
 
         final XSSFConditionalFormattingRule badDataRule =
-                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%s),%s<0)",
-                        detailCell.getAddress().formatAsString(),
+                formatting.createConditionalFormattingRule(String.format("AND(ISNUMBER(%1$s),%1$s<0)",
                         detailCell.getAddress().formatAsString()));
         final XSSFPatternFormatting badDataRulePatternFormatting = badDataRule.createPatternFormatting();
         final XSSFColor badDataBackgroundColor = new XSSFColor(new byte[]{(byte) 255, (byte) 204, (byte) 204}, null);
@@ -372,8 +375,11 @@ public class GapReportBuilder {
     }
 
     /**
-     * @param filter
-     * @return
+     * Extract filter values from a {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}.
+     *
+     * @param filter The {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter} to get values from
+     * @return A {@link java.util.List} of {@link java.lang.String}s containing the values of the search filters passed
+     * into the {@link org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport}
      */
     private List<String> getFilterValues(final SearchFilter filter) {
         List<String> searchFilterValues;
@@ -406,9 +412,12 @@ public class GapReportBuilder {
     }
 
     /**
+     * Get a collection of {@link org.apache.poi.xssf.usermodel.XSSFCellStyle}s to apply to the
+     * {@link org.apache.poi.xssf.usermodel.XSSFSheet}s in the report.
      *
-     * @param xssfWorkbook
-     * @return
+     * @param xssfWorkbook The {@link org.apache.poi.xssf.usermodel.XSSFWorkbook} that owns the styles
+     * @return A {@link java.util.Map} of {@link String}s and {@link org.apache.poi.xssf.usermodel.XSSFCellStyle}s that
+     * can be applied to the report.
      */
     private Map<String, XSSFCellStyle> getStyles(final XSSFWorkbook xssfWorkbook) {
         final Map<String, XSSFCellStyle> cellStyleMap = new HashMap<>();
@@ -427,14 +436,10 @@ public class GapReportBuilder {
         italicFont.setFontName(fontName);
         italicFont.setColor(IndexedColors.GREY_25_PERCENT.index);
 
-        final XSSFFont goodDataFont = xssfWorkbook.createFont();
-        goodDataFont.setFontName(fontName);
-        goodDataFont.setColor(IndexedColors.DARK_GREEN.index);
-
-        final XSSFFont badDataFont = xssfWorkbook.createFont();
-        badDataFont.setFontName(fontName);
-        badDataFont.setColor(IndexedColors.DARK_RED.index);
-        badDataFont.setBold(true);
+        final XSSFFont reportHeaderFont = xssfWorkbook.createFont();
+        reportHeaderFont.setBold(true);
+        reportHeaderFont.setFontHeightInPoints((short)16);
+        reportHeaderFont.setColor(IndexedColors.GREY_80_PERCENT.index);
 
         final XSSFCellStyle boldTextCellStyle = xssfWorkbook.createCellStyle();
         boldTextCellStyle.setFont(boldFont);
@@ -444,7 +449,7 @@ public class GapReportBuilder {
         noRecordCellStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.index);
 
         final XSSFCellStyle reportDetailsHeaderCellStyle = xssfWorkbook.createCellStyle();
-        reportDetailsHeaderCellStyle.setFont(boldFont);
+        reportDetailsHeaderCellStyle.setFont(reportHeaderFont);
         reportDetailsHeaderCellStyle.setBorderTop(BorderStyle.NONE);
         reportDetailsHeaderCellStyle.setBorderRight(BorderStyle.NONE);
         reportDetailsHeaderCellStyle.setBorderLeft(BorderStyle.NONE);
@@ -452,7 +457,6 @@ public class GapReportBuilder {
         reportDetailsHeaderCellStyle.setBorderColor(XSSFCellBorder.BorderSide.BOTTOM,
                 new XSSFColor(IndexedColors.CORNFLOWER_BLUE,
                         new DefaultIndexedColorMap()));
-        reportDetailsHeaderCellStyle.getFont().setFontHeightInPoints((short) 15);
 
         cellStyleMap.put(CELL_STYLE_BOLD_TEXT, boldTextCellStyle);
         cellStyleMap.put(CELL_STYLE_NO_RECORDS, noRecordCellStyle);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportCalculationField.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportCalculationField.java
@@ -1,0 +1,32 @@
+package org.opentestsystem.ap.imrt.iss.model.reports.gap;
+
+public enum GapReportCalculationField {
+    DESIRED_DIFFICULTY_COUNT("desiredDifficulty0"),
+    DESIRED_DIFFICULTY_ONE("desiredDifficulty1"),
+    DESIRED_DIFFICULTY_TWO("desiredDifficulty2"),
+    DESIRED_DIFFICULTY_THREE("desiredDifficulty3"),
+    DESIRED_DIFFICULTY_FOUR("desiredDifficulty4"),
+    DESIRED_DIFFICULTY_FIVE("desiredDifficulty5"),
+    ACTUAL_DIFFICULTY_COUNT("actualDifficulty0"),
+    ACTUAL_DIFFICULTY_ONE("actualDifficulty1"),
+    ACTUAL_DIFFICULTY_TWO("actualDifficulty2"),
+    ACTUAL_DIFFICULTY_THREE("actualDifficulty3"),
+    ACTUAL_DIFFICULTY_FOUR("actualDifficulty4"),
+    ACTUAL_DIFFICULTY_FIVE("actualDifficulty5"),
+    DELTA_DIFFICULTY_COUNT("deltaDifficulty0"),
+    DELTA_DIFFICULTY_ONE("deltaDifficulty1"),
+    DELTA_DIFFICULTY_TWO("deltaDifficulty2"),
+    DELTA_DIFFICULTY_THREE("deltaDifficulty3"),
+    DELTA_DIFFICULTY_FOUR("deltaDifficulty4"),
+    DELTA_DIFFICULTY_FIVE("deltaDifficulty5");
+
+    private final String fieldName;
+
+    GapReportCalculationField(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportCalculationField.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/model/reports/gap/GapReportCalculationField.java
@@ -1,5 +1,8 @@
 package org.opentestsystem.ap.imrt.iss.model.reports.gap;
 
+/**
+ * Enumerate the calculation fields for the Gap Report.
+ */
 public enum GapReportCalculationField {
     DESIRED_DIFFICULTY_COUNT("desiredDifficulty0"),
     DESIRED_DIFFICULTY_ONE("desiredDifficulty1"),
@@ -26,6 +29,9 @@ public enum GapReportCalculationField {
         this.fieldName = fieldName;
     }
 
+    /**
+     * @return The name of the field
+     */
     public String getFieldName() {
         return fieldName;
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepository.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepository.java
@@ -7,7 +7,20 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * An interface for interacting with data retrieval for the Gap Report.
+ */
 public interface GapReportRepository {
+    /**
+     * Get the Gap Report data.
+     *
+     * @param searchFilters The collection of {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s supplied by the
+     *                      user.  These narrow down the number of items that are counted.
+     * @param groups The collection of {@link org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty}s supplied by the
+     *               user.  These dictate how the difficulty quintile counts are grouped.
+     * @return A collection of {@link Map}s, where the key is the name of the column in the result set and the value is
+     * the data for that column.  Each {@link java.util.Map} in the result is a row from the database.
+     */
     List<Map<String, Object>> getGapReport(final Collection<SearchFilter> searchFilters,
-                                           final Collection<SearchProperty> groupFilters);
+                                           final Collection<SearchProperty> groups);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepository.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepository.java
@@ -1,0 +1,13 @@
+package org.opentestsystem.ap.imrt.iss.repository;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface GapReportRepository {
+    List<Map<String, Object>> getGapReport(final Collection<SearchFilter> searchFilters,
+                                           final Collection<SearchProperty> groupFilters);
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -3,9 +3,6 @@ package org.opentestsystem.ap.imrt.iss.repository;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.dto.search.Sort;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -68,7 +65,6 @@ import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculat
 
 @Repository
 public class GapReportRepositoryImpl implements GapReportRepository {
-    private static final Logger LOG = LoggerFactory.getLogger(GapReportRepositoryImpl.class);
     private static Map<String, Integer> orderByRankMap;
 
     static {
@@ -111,7 +107,7 @@ public class GapReportRepositoryImpl implements GapReportRepository {
                     "'' AS " + DESIRED_DIFFICULTY_TWO.getFieldName() + ", \n" +
                     "'' AS " + DESIRED_DIFFICULTY_THREE.getFieldName() + ", \n" +
                     "'' AS " + DESIRED_DIFFICULTY_FOUR.getFieldName() + ", \n" +
-                    "'' AS " +  DESIRED_DIFFICULTY_FIVE.getFieldName() + ", \n" +
+                    "'' AS " + DESIRED_DIFFICULTY_FIVE.getFieldName() + ", \n" +
                     "count(key) AS " + ACTUAL_DIFFICULTY_COUNT.getFieldName() + ", \n" +
                     "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_ONE.getFieldName() + ", \n" +
                     "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_TWO.getFieldName() + ", \n" +
@@ -122,7 +118,7 @@ public class GapReportRepositoryImpl implements GapReportRepository {
                     "'' AS " + DELTA_DIFFICULTY_ONE.getFieldName() + ", \n" +
                     "'' AS " + DELTA_DIFFICULTY_TWO.getFieldName() + ", \n" +
                     "'' AS " + DELTA_DIFFICULTY_THREE.getFieldName() + ", \n" +
-                    "'' AS " + DELTA_DIFFICULTY_FOUR.getFieldName() +  ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_FOUR.getFieldName() + ", \n" +
                     "'' AS " + DELTA_DIFFICULTY_FIVE.getFieldName() + " \n";
 
     @Autowired
@@ -152,6 +148,14 @@ public class GapReportRepositoryImpl implements GapReportRepository {
                 orderBy,
                 baseSql);
 
-        return namedParameterJdbcTemplate.queryForList(query.getSearchQuery(), query.getMapSqlParameterSource());
+        // Stimulus and tutorial items should be excluded from the gap report data
+        final String excludeStimulusAndTutorialItemsSql = query.getSearchQuery().contains("WHERE")
+                ? " AND (item_type NOT IN ('stim', 'tut')) \n"
+                : " WHERE (item_type NOT IN ('stim', 'tut')) \n";
+        final String sql = new StringBuilder(query.getSearchQuery())
+                .insert(query.getSearchQuery().indexOf("GROUP BY"), excludeStimulusAndTutorialItemsSql)
+                .toString();
+
+        return namedParameterJdbcTemplate.queryForList(sql, query.getMapSqlParameterSource());
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -88,11 +88,12 @@ public class GapReportRepositoryImpl implements GapReportRepository {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final SearchFilterQueryBuilder searchFilterQueryBuilder;
     private final String QUINTILE_DIFFICULTY_COUNTS_SQL =
-            "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS difficulty_1, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS difficulty_2, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS difficulty_3, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS difficulty_4, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS difficulty_5 \n";
+            "count(key) AS actual, \n" +
+            "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS actual_difficulty_1, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS actual_difficulty_2, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS actual_difficulty_3, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS actual_difficulty_4, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS actual_difficulty_5 \n";
 
     @Autowired
     public GapReportRepositoryImpl(final NamedParameterJdbcTemplate namedParameterJdbcTemplate,

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -87,7 +87,7 @@ public class GapReportRepositoryImpl implements GapReportRepository {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final SearchFilterQueryBuilder searchFilterQueryBuilder;
     private final String QUINTILE_DIFFICULTY_COUNTS_SQL =
-            "null AS desired, \n" +
+            "null AS desired_difficulty_count, \n" +
                     "'' AS desired_difficulty_1, \n" +
                     "'' AS desired_difficulty_2, \n" +
                     "'' AS desired_difficulty_3, \n" +

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -15,7 +15,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
@@ -88,12 +87,24 @@ public class GapReportRepositoryImpl implements GapReportRepository {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final SearchFilterQueryBuilder searchFilterQueryBuilder;
     private final String QUINTILE_DIFFICULTY_COUNTS_SQL =
-            "count(key) AS actual, \n" +
-            "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS actual_difficulty_1, \n" +
+            "null AS desired, \n" +
+                    "'' AS desired_difficulty_1, \n" +
+                    "'' AS desired_difficulty_2, \n" +
+                    "'' AS desired_difficulty_3, \n" +
+                    "'' AS desired_difficulty_4, \n" +
+                    "'' AS desired_difficulty_5, \n" +
+                    "count(key) AS actual_difficulty_count, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS actual_difficulty_1, \n" +
                     "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS actual_difficulty_2, \n" +
                     "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS actual_difficulty_3, \n" +
                     "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS actual_difficulty_4, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS actual_difficulty_5 \n";
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS actual_difficulty_5, \n" +
+                    "'' AS delta_difficulty_count, \n" +
+                    "'' AS delta_difficulty_1, \n" +
+                    "'' AS delta_difficulty_2, \n" +
+                    "'' AS delta_difficulty_3, \n" +
+                    "'' AS delta_difficulty_4, \n" +
+                    "'' AS delta_difficulty_5 \n";
 
     @Autowired
     public GapReportRepositoryImpl(final NamedParameterJdbcTemplate namedParameterJdbcTemplate,

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -18,13 +18,16 @@ import java.util.stream.Collectors;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_RESOLUTION;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.DOK;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ENGLISH_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.HAS_UNRESOLVED_UPDATE_NEED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_REQUIRED;
-import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_DIFFICULTY_QUINTILE;
-import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_NAME;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_TYPE_ID;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CLAIM;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_COMMON_CORE_STANDARD;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CONTENT_DOMAIN;
@@ -37,13 +40,14 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_COMMON_CORE_STANDARD;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_TARGET;
-import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CLAIM;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_COMMON_CORE_STANDARD;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
 import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_COUNT;
 import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FIVE;
 import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FOUR;
@@ -97,6 +101,10 @@ public class GapReportRepositoryImpl implements GapReportRepository {
         orderByRankMap.put(PRIMARY_TARGET.getColumnName(), 26);
         orderByRankMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), 27);
         orderByRankMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), 28);
+        orderByRankMap.put(DOK.getColumnName(), -1);
+        orderByRankMap.put(WORKFLOW_STATUS.getColumnName(), -1);
+        orderByRankMap.put(ORGANIZATION_TYPE_ID.getColumnName(), -1);
+        orderByRankMap.put(ORGANIZATION_NAME.getColumnName(), -1);
     }
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -23,9 +23,10 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ENGLISH_G
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.HAS_UNRESOLVED_UPDATE_NEED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_REQUIRED;
-//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_AUTHOR;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_DIFFICULTY_QUINTILE;
-//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_NAME;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ORGANIZATION_TYPE_ID;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CLAIM;
@@ -40,11 +41,12 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_COMMON_CORE_STANDARD;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_TARGET;
-//import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CLAIM;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_COMMON_CORE_STANDARD;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CONTENT_DOMAIN;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TEST_CATEGORY;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.WORKFLOW_STATUS;
@@ -69,6 +71,9 @@ import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculat
 
 @Repository
 public class GapReportRepositoryImpl implements GapReportRepository {
+    // A map to dictate the ORDER BY clause of the gap report query.  Results should be ordered by least variant to
+    // most variant.  In the case where the fields were equally variant (e.g. a boolean field), the fields are sorted in
+    // alphabetical order.
     private static Map<String, Integer> orderByRankMap;
 
     static {
@@ -83,28 +88,30 @@ public class GapReportRepositoryImpl implements GapReportRepository {
         orderByRankMap.put(ILLUSTRATED_GLOSSARY_REQUIRED.getColumnName(), 8);
         orderByRankMap.put(TRANSLATED_GLOSSARY_REQUIRED.getColumnName(), 9);
         orderByRankMap.put(SUBJECT.getColumnName(), 10);
-        orderByRankMap.put(PRIMARY_CLAIM.getColumnName(), 11);
-        orderByRankMap.put(QUATERNARY_CLAIM.getColumnName(), 12);
-        orderByRankMap.put(SECONDARY_CLAIM.getColumnName(), 13);
-        orderByRankMap.put(TERTIARY_CLAIM.getColumnName(), 14);
-        orderByRankMap.put(INTENDED_GRADE.getColumnName(), 15);
-        orderByRankMap.put(QUATERNARY_TARGET.getColumnName(), 16);
-        orderByRankMap.put(SECONDARY_TARGET.getColumnName(), 17);
-        orderByRankMap.put(QUATERNARY_CONTENT_DOMAIN.getColumnName(), 18);
-        orderByRankMap.put(ITEM_TYPE.getColumnName(), 19);
-        orderByRankMap.put(QUATERNARY_COMMON_CORE_STANDARD.getColumnName(), 20);
-        orderByRankMap.put(TERTIARY_COMMON_CORE_STANDARD.getColumnName(), 21);
-        orderByRankMap.put(TERTIARY_TARGET.getColumnName(), 22);
-        orderByRankMap.put(TERTIARY_CONTENT_DOMAIN.getColumnName(), 23);
-        orderByRankMap.put(SECONDARY_CONTENT_DOMAIN.getColumnName(), 24);
+        orderByRankMap.put(TEST_CATEGORY.getColumnName(), 11);
+        orderByRankMap.put(DOK.getColumnName(), 12);
+        orderByRankMap.put(ORGANIZATION_TYPE_ID.getColumnName(), 13);
+        orderByRankMap.put(PRIMARY_CLAIM.getColumnName(), 14);
+        orderByRankMap.put(QUATERNARY_CLAIM.getColumnName(), 15);
+        orderByRankMap.put(SECONDARY_CLAIM.getColumnName(), 16);
+        orderByRankMap.put(TERTIARY_CLAIM.getColumnName(), 17);
+        orderByRankMap.put(INTENDED_GRADE.getColumnName(), 18);
+        orderByRankMap.put(QUATERNARY_TARGET.getColumnName(), 19);
+        orderByRankMap.put(SECONDARY_TARGET.getColumnName(), 20);
+        orderByRankMap.put(ITEM_TYPE.getColumnName(), 21);
+        orderByRankMap.put(QUATERNARY_COMMON_CORE_STANDARD.getColumnName(), 22);
+        orderByRankMap.put(TERTIARY_COMMON_CORE_STANDARD.getColumnName(), 23);
+        orderByRankMap.put(TERTIARY_TARGET.getColumnName(), 24);
         orderByRankMap.put(SECONDARY_COMMON_CORE_STANDARD.getColumnName(), 25);
-        orderByRankMap.put(PRIMARY_TARGET.getColumnName(), 26);
-        orderByRankMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), 27);
-        orderByRankMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), 28);
-        orderByRankMap.put(DOK.getColumnName(), -1);
-        orderByRankMap.put(WORKFLOW_STATUS.getColumnName(), -1);
-        orderByRankMap.put(ORGANIZATION_TYPE_ID.getColumnName(), -1);
-        orderByRankMap.put(ORGANIZATION_NAME.getColumnName(), -1);
+        orderByRankMap.put(WORKFLOW_STATUS.getColumnName(), 26);
+        orderByRankMap.put(PRIMARY_TARGET.getColumnName(), 27);
+        orderByRankMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), 28);
+        orderByRankMap.put(ITEM_AUTHOR.getColumnName(), 29);
+        orderByRankMap.put(ORGANIZATION_NAME.getColumnName(), 30);
+        orderByRankMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), 31);
+        orderByRankMap.put(SECONDARY_CONTENT_DOMAIN.getColumnName(), 32);
+        orderByRankMap.put(TERTIARY_CONTENT_DOMAIN.getColumnName(), 33);
+        orderByRankMap.put(QUATERNARY_CONTENT_DOMAIN.getColumnName(), 34);
     }
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
@@ -138,8 +145,8 @@ public class GapReportRepositoryImpl implements GapReportRepository {
 
     @Override
     public List<Map<String, Object>> getGapReport(final Collection<SearchFilter> searchFilters,
-                                                  final Collection<SearchProperty> groupFilters) {
-        final String joinedGroupFilters = groupFilters.stream()
+                                                  final Collection<SearchProperty> groups) {
+        final String joinedGroupFilters = groups.stream()
                 .map(gf -> gf.getColumnName() + " AS " + gf.getProperty())
                 .collect(Collectors.joining(",\n"));
         final String baseSql = "SELECT \n"
@@ -147,12 +154,12 @@ public class GapReportRepositoryImpl implements GapReportRepository {
                 + QUINTILE_DIFFICULTY_COUNTS_SQL
                 + "FROM \n" +
                 "item \n";
-        final Collection<Sort> orderBy = groupFilters.stream()
+        final Collection<Sort> orderBy = groups.stream()
                 .sorted(Comparator.comparing(filterProp -> orderByRankMap.getOrDefault(filterProp.getColumnName(), 0)))
                 .map(filterProp -> new Sort(filterProp.getProperty(), Sort.Direction.ASC))
                 .collect(Collectors.toList());
         final SearchQuery query = searchFilterQueryBuilder.buildQuery(new ArrayList<>(searchFilters),
-                groupFilters,
+                groups,
                 orderBy,
                 baseSql);
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.opentestsystem.ap.imrt.iss.repository;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.dto.search.Sort;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +47,24 @@ import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_TARGET;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_TWO;
 
 @Repository
 public class GapReportRepositoryImpl implements GapReportRepository {
@@ -87,24 +106,24 @@ public class GapReportRepositoryImpl implements GapReportRepository {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final SearchFilterQueryBuilder searchFilterQueryBuilder;
     private final String QUINTILE_DIFFICULTY_COUNTS_SQL =
-            "null AS desired_difficulty_count, \n" +
-                    "'' AS desired_difficulty_1, \n" +
-                    "'' AS desired_difficulty_2, \n" +
-                    "'' AS desired_difficulty_3, \n" +
-                    "'' AS desired_difficulty_4, \n" +
-                    "'' AS desired_difficulty_5, \n" +
-                    "count(key) AS actual_difficulty_count, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS actual_difficulty_1, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS actual_difficulty_2, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS actual_difficulty_3, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS actual_difficulty_4, \n" +
-                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS actual_difficulty_5, \n" +
-                    "'' AS delta_difficulty_count, \n" +
-                    "'' AS delta_difficulty_1, \n" +
-                    "'' AS delta_difficulty_2, \n" +
-                    "'' AS delta_difficulty_3, \n" +
-                    "'' AS delta_difficulty_4, \n" +
-                    "'' AS delta_difficulty_5 \n";
+            "null AS " + DESIRED_DIFFICULTY_COUNT.getFieldName() + ", \n" +
+                    "'' AS " + DESIRED_DIFFICULTY_ONE.getFieldName() + ", \n" +
+                    "'' AS " + DESIRED_DIFFICULTY_TWO.getFieldName() + ", \n" +
+                    "'' AS " + DESIRED_DIFFICULTY_THREE.getFieldName() + ", \n" +
+                    "'' AS " + DESIRED_DIFFICULTY_FOUR.getFieldName() + ", \n" +
+                    "'' AS " +  DESIRED_DIFFICULTY_FIVE.getFieldName() + ", \n" +
+                    "count(key) AS " + ACTUAL_DIFFICULTY_COUNT.getFieldName() + ", \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_ONE.getFieldName() + ", \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_TWO.getFieldName() + ", \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_THREE.getFieldName() + ", \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_FOUR.getFieldName() + ", \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS " + ACTUAL_DIFFICULTY_FIVE.getFieldName() + ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_COUNT.getFieldName() + ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_ONE.getFieldName() + ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_TWO.getFieldName() + ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_THREE.getFieldName() + ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_FOUR.getFieldName() +  ", \n" +
+                    "'' AS " + DELTA_DIFFICULTY_FIVE.getFieldName() + " \n";
 
     @Autowired
     public GapReportRepositoryImpl(final NamedParameterJdbcTemplate namedParameterJdbcTemplate,
@@ -117,7 +136,7 @@ public class GapReportRepositoryImpl implements GapReportRepository {
     public List<Map<String, Object>> getGapReport(final Collection<SearchFilter> searchFilters,
                                                   final Collection<SearchProperty> groupFilters) {
         final String joinedGroupFilters = groupFilters.stream()
-                .map(SearchProperty::getColumnName)
+                .map(gf -> gf.getColumnName() + " AS " + gf.getProperty())
                 .collect(Collectors.joining(",\n"));
         final String baseSql = "SELECT \n"
                 + joinedGroupFilters + ", \n"

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImpl.java
@@ -1,0 +1,126 @@
+package org.opentestsystem.ap.imrt.iss.repository;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.dto.search.Sort;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CONTENT_CHANGED_AFTER_OPERATIONAL;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.CURRENT_UPDATE_NEED_RESOLUTION;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ENGLISH_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.HAS_UNRESOLVED_UPDATE_NEED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ILLUSTRATED_GLOSSARY_REQUIRED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_DIFFICULTY_QUINTILE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.PRIMARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.QUATERNARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SECONDARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CLAIM;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_COMMON_CORE_STANDARD;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_CONTENT_DOMAIN;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TERTIARY_TARGET;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_PROVIDED;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.TRANSLATED_GLOSSARY_REQUIRED;
+
+@Repository
+public class GapReportRepositoryImpl implements GapReportRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(GapReportRepositoryImpl.class);
+    private static Map<String, Integer> orderByRankMap;
+
+    static {
+        orderByRankMap = new HashMap<>();
+        orderByRankMap.put(CONTENT_CHANGED_AFTER_OPERATIONAL.getColumnName(), 1);
+        orderByRankMap.put(CURRENT_UPDATE_NEED_INTERNAL_RESOLUTION.getColumnName(), 2);
+        orderByRankMap.put(CURRENT_UPDATE_NEED_RESOLUTION.getColumnName(), 3);
+        orderByRankMap.put(ENGLISH_GLOSSARY_PROVIDED.getColumnName(), 4);
+        orderByRankMap.put(ILLUSTRATED_GLOSSARY_PROVIDED.getColumnName(), 5);
+        orderByRankMap.put(TRANSLATED_GLOSSARY_PROVIDED.getColumnName(), 6);
+        orderByRankMap.put(HAS_UNRESOLVED_UPDATE_NEED.getColumnName(), 7);
+        orderByRankMap.put(ILLUSTRATED_GLOSSARY_REQUIRED.getColumnName(), 8);
+        orderByRankMap.put(TRANSLATED_GLOSSARY_REQUIRED.getColumnName(), 9);
+        orderByRankMap.put(SUBJECT.getColumnName(), 10);
+        orderByRankMap.put(PRIMARY_CLAIM.getColumnName(), 11);
+        orderByRankMap.put(QUATERNARY_CLAIM.getColumnName(), 12);
+        orderByRankMap.put(SECONDARY_CLAIM.getColumnName(), 13);
+        orderByRankMap.put(TERTIARY_CLAIM.getColumnName(), 14);
+        orderByRankMap.put(INTENDED_GRADE.getColumnName(), 15);
+        orderByRankMap.put(QUATERNARY_TARGET.getColumnName(), 16);
+        orderByRankMap.put(SECONDARY_TARGET.getColumnName(), 17);
+        orderByRankMap.put(QUATERNARY_CONTENT_DOMAIN.getColumnName(), 18);
+        orderByRankMap.put(ITEM_TYPE.getColumnName(), 19);
+        orderByRankMap.put(QUATERNARY_COMMON_CORE_STANDARD.getColumnName(), 20);
+        orderByRankMap.put(TERTIARY_COMMON_CORE_STANDARD.getColumnName(), 21);
+        orderByRankMap.put(TERTIARY_TARGET.getColumnName(), 22);
+        orderByRankMap.put(TERTIARY_CONTENT_DOMAIN.getColumnName(), 23);
+        orderByRankMap.put(SECONDARY_CONTENT_DOMAIN.getColumnName(), 24);
+        orderByRankMap.put(SECONDARY_COMMON_CORE_STANDARD.getColumnName(), 25);
+        orderByRankMap.put(PRIMARY_TARGET.getColumnName(), 26);
+        orderByRankMap.put(PRIMARY_COMMON_CORE_STANDARD.getColumnName(), 27);
+        orderByRankMap.put(PRIMARY_CONTENT_DOMAIN.getColumnName(), 28);
+    }
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final SearchFilterQueryBuilder searchFilterQueryBuilder;
+    private final String QUINTILE_DIFFICULTY_COUNTS_SQL =
+            "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '1' THEN 1 ELSE 0 END) AS difficulty_1, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '2' THEN 1 ELSE 0 END) AS difficulty_2, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '3' THEN 1 ELSE 0 END) AS difficulty_3, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '4' THEN 1 ELSE 0 END) AS difficulty_4, \n" +
+                    "sum(CASE WHEN " + ITEM_DIFFICULTY_QUINTILE.getColumnName() + " = '5' THEN 1 ELSE 0 END) AS difficulty_5 \n";
+
+    @Autowired
+    public GapReportRepositoryImpl(final NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+                                   final SearchFilterQueryBuilder searchFilterQueryBuilder) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+        this.searchFilterQueryBuilder = searchFilterQueryBuilder;
+    }
+
+    @Override
+    public List<Map<String, Object>> getGapReport(final Collection<SearchFilter> searchFilters,
+                                                  final Collection<SearchProperty> groupFilters) {
+        final String joinedGroupFilters = groupFilters.stream()
+                .map(SearchProperty::getColumnName)
+                .collect(Collectors.joining(",\n"));
+        final String baseSql = "SELECT \n"
+                + joinedGroupFilters + ", \n"
+                + QUINTILE_DIFFICULTY_COUNTS_SQL
+                + "FROM \n" +
+                "item \n";
+        final Collection<Sort> orderBy = groupFilters.stream()
+                .sorted(Comparator.comparing(filterProp -> orderByRankMap.getOrDefault(filterProp.getColumnName(), 0)))
+                .map(filterProp -> new Sort(filterProp.getProperty(), Sort.Direction.ASC))
+                .collect(Collectors.toList());
+        final SearchQuery query = searchFilterQueryBuilder.buildQuery(new ArrayList<>(searchFilters),
+                groupFilters,
+                orderBy,
+                baseSql);
+
+        return namedParameterJdbcTemplate.queryForList(query.getSearchQuery(), query.getMapSqlParameterSource());
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/repository/SearchFilterQueryBuilder.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/repository/SearchFilterQueryBuilder.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.imrt.iss.repository;
 
+import org.apache.commons.collections4.IterableUtils;
 import org.opentestsystem.ap.imrt.iss.dto.search.PageDto;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.dto.search.Sort;
@@ -15,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Handles building queries for general search
@@ -56,7 +58,23 @@ public class SearchFilterQueryBuilder {
      * @return a query leveraging the passed in arguments which will filter, order, page, and sort as appropriate.
      */
     SearchQuery buildQuery(final List<SearchFilter> searchFilters, SearchProperty groupBy, final String baseQuery) {
-        return buildQuery(Optional.empty(), Collections.emptyList(), searchFilters, Optional.of(groupBy), baseQuery);
+        return buildQuery(Optional.empty(), Collections.emptyList(), searchFilters, Optional.of(Collections.singletonList(groupBy)), baseQuery);
+    }
+
+    /**
+     * Builds WHERE query for multiple GROUP BY and ORDER BY fields
+     *
+     * @param searchFilters the {@link SearchFilter} which are used to filter the results
+     * @param groupBy the {@link SearchProperty}s to group results for counts
+     * @param sorts the {@link Sort}s to apply to the results
+     * @param baseQuery the base query for the select.  Must include the "FROM item"
+     * @return a query leveraging the passed in arguments which will filter, order, page, and sort as appropriate.
+     */
+    SearchQuery buildQuery(final List<SearchFilter> searchFilters,
+                           final Collection<SearchProperty> groupBy,
+                           final Collection<Sort> sorts,
+                           final String baseQuery) {
+        return buildQuery(Optional.empty(), sorts, searchFilters, Optional.of(groupBy), baseQuery);
     }
 
     /**
@@ -69,7 +87,7 @@ public class SearchFilterQueryBuilder {
      * @param baseQuery     the base query for the select.  Must include the "FROM item"
      * @return a query leveraging the passed in arguments which will filter, order, page, and sort as appropriate.
      */
-    private SearchQuery buildQuery(final Optional<PageDto> maybePageDto, final Collection<Sort> sorts, final List<SearchFilter> searchFilters, Optional<SearchProperty> maybeGroupBy, final String baseQuery) {
+    private SearchQuery buildQuery(final Optional<PageDto> maybePageDto, final Collection<Sort> sorts, final List<SearchFilter> searchFilters, Optional<Collection<SearchProperty>> maybeGroupBy, final String baseQuery) {
         StringBuilder sb = new StringBuilder(baseQuery);
         Set<String> tables = new HashSet<>();
         MapSqlParameterSource sqlParameterSource = new MapSqlParameterSource();
@@ -97,7 +115,13 @@ public class SearchFilterQueryBuilder {
             }
         }
 
-        maybeGroupBy.ifPresent(searchProperty -> sb.append(" GROUP BY ").append(searchProperty.getColumnName()).append(" "));
+        //maybeGroupBy.ifPresent(searchProperty -> sb.append(" GROUP BY ").append(searchProperty.getColumnName()).append(" "));
+        if (maybeGroupBy.isPresent()) {
+            sb.append(" GROUP BY ");
+            sb.append(maybeGroupBy.get().stream()
+                    .map(SearchProperty::getColumnName)
+                    .collect(Collectors.joining(", ")));
+        }
 
         if (!sorts.isEmpty()) {
             sb.append(" ORDER BY ");

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
@@ -1,0 +1,12 @@
+package org.opentestsystem.ap.imrt.iss.service;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface GapReportService {
+    Optional<GapReport> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters);
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
@@ -1,12 +1,12 @@
 package org.opentestsystem.ap.imrt.iss.service;
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
 
 import java.util.Collection;
 import java.util.Optional;
 
 public interface GapReportService {
-    Optional<GapReport> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters);
+    Optional<XSSFWorkbook> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
@@ -1,12 +1,13 @@
 package org.opentestsystem.ap.imrt.iss.service;
 
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
 
 public interface GapReportService {
-    Optional<XSSFWorkbook> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters);
+    Optional<File> getGapReport(final Collection<SearchFilter> searchFilters,
+                                final Collection<SearchProperty> groups);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportService.java
@@ -7,7 +7,18 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * Interface for interacting with the Gap Report.
+ */
 public interface GapReportService {
+    /**
+     * Get the Gap Report as a {@link java.io.File} for delivery to the caller.
+     *
+     * @param searchFilters The {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s provided by the user
+     * @param groups The {@link org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty}s by which the difficulty
+     *               quintile counts should be grouped
+     * @return A {@link File} containing the Gap Report data.
+     */
     Optional<File> getGapReport(final Collection<SearchFilter> searchFilters,
                                 final Collection<SearchProperty> groups);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -4,6 +4,7 @@ import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
 import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
+import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@Service
 public class GapReportServiceImpl implements GapReportService {
     private final GapReportRepository gapReportRepository;
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class GapReportServiceImpl implements GapReportService {
@@ -39,6 +40,15 @@ public class GapReportServiceImpl implements GapReportService {
                                        final Collection<SearchProperty> groups) {
         if (containsInvalidFilters(searchFilters)) {
             return Optional.empty();
+        }
+
+        final List<String> invalidGroupProperties = groups.stream()
+                .filter(g -> !g.isSupportsCounts())
+                .map(SearchProperty::getProperty)
+                .collect(Collectors.toList());
+
+        if (!invalidGroupProperties.isEmpty()) {
+            throw new IllegalArgumentException("The following group(s) are not supported: " + String.join(", ", invalidGroupProperties));
         }
 
         final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groups);

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -32,6 +32,8 @@ public class GapReportServiceImpl implements GapReportService {
             return Optional.empty();
         }
 
+        // TODO:  Add filters to exclude TUT and Stimuli items
+
         final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groupFilters);
 
         final XSSFWorkbook workbook = gapReportBuilder.getReport(new GapReport(searchFilters,

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -8,11 +8,20 @@ import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class GapReportServiceImpl implements GapReportService {
@@ -26,22 +35,34 @@ public class GapReportServiceImpl implements GapReportService {
     }
 
     @Override
-    public Optional<XSSFWorkbook> getGapReport(final Collection<SearchFilter> searchFilters,
-                                               final Collection<SearchProperty> groupFilters) {
+    public Optional<File> getGapReport(final Collection<SearchFilter> searchFilters,
+                                       final Collection<SearchProperty> groups) {
         if (containsInvalidFilters(searchFilters)) {
             return Optional.empty();
         }
 
         // TODO:  Add filters to exclude TUT and Stimuli items
 
-        final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groupFilters);
+        final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groups);
 
         final XSSFWorkbook workbook = gapReportBuilder.getReport(new GapReport(searchFilters,
-                groupFilters,
+                groups,
                 results,
                 Instant.now()));
 
-        return Optional.of(workbook);
+        try {
+            final Path path = Files.createTempDirectory(UUID.randomUUID().toString());
+            final DateFormat df = new SimpleDateFormat("yyyyMMddhhmmss");
+            final File excelFile = new File(path.toFile(), "gap-report-" + df.format(new Date()) + ".xlsx");
+
+            try (final FileOutputStream fso = new FileOutputStream(excelFile)) {
+                workbook.write(fso);
+            }
+
+            return Optional.of(excelFile);
+        } catch (final IOException e) {
+            throw new RuntimeException("Unhandled exception while creating Gap Report excel file", e);
+        }
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -1,0 +1,42 @@
+package org.opentestsystem.ap.imrt.iss.service;
+
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class GapReportServiceImpl implements GapReportService {
+    private final GapReportRepository gapReportRepository;
+
+    public GapReportServiceImpl(final GapReportRepository gapReportRepository) {
+        this.gapReportRepository = gapReportRepository;
+    }
+
+    @Override
+    public Optional<GapReport> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters) {
+        if (containsInvalidFilters(searchFilters)) {
+            return Optional.empty();
+        }
+
+        final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groupFilters);
+
+        return Optional.of(new GapReport(searchFilters, groupFilters, results, Instant.now()));
+    }
+
+    /**
+     * Determine if any of the {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s contain invalid values.
+     *
+     * @param filters The collection of {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s to evaluate
+     * @return True if any of the {@link org.opentestsystem.ap.imrt.iss.model.SearchFilter}s are invalid; otherwise
+     * false
+     */
+    private boolean containsInvalidFilters(Collection<SearchFilter> filters) {
+        return filters.stream().anyMatch(searchFilter -> !searchFilter.containsValidFilterValues());
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -1,8 +1,10 @@
 package org.opentestsystem.ap.imrt.iss.service;
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
 import org.springframework.stereotype.Service;
 
@@ -15,20 +17,29 @@ import java.util.Optional;
 @Service
 public class GapReportServiceImpl implements GapReportService {
     private final GapReportRepository gapReportRepository;
+    private final GapReportBuilder gapReportBuilder;
 
-    public GapReportServiceImpl(final GapReportRepository gapReportRepository) {
+    public GapReportServiceImpl(final GapReportRepository gapReportRepository,
+                                final GapReportBuilder gapReportBuilder) {
         this.gapReportRepository = gapReportRepository;
+        this.gapReportBuilder = gapReportBuilder;
     }
 
     @Override
-    public Optional<GapReport> getGapReport(final Collection<SearchFilter> searchFilters, final Collection<SearchProperty> groupFilters) {
+    public Optional<XSSFWorkbook> getGapReport(final Collection<SearchFilter> searchFilters,
+                                               final Collection<SearchProperty> groupFilters) {
         if (containsInvalidFilters(searchFilters)) {
             return Optional.empty();
         }
 
         final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groupFilters);
 
-        return Optional.of(new GapReport(searchFilters, groupFilters, results, Instant.now()));
+        final XSSFWorkbook workbook = gapReportBuilder.getReport(new GapReport(searchFilters,
+                groupFilters,
+                results,
+                Instant.now()));
+
+        return Optional.of(workbook);
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -41,8 +41,6 @@ public class GapReportServiceImpl implements GapReportService {
             return Optional.empty();
         }
 
-        // TODO:  Add filters to exclude TUT and Stimuli items
-
         final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groups);
 
         final XSSFWorkbook workbook = gapReportBuilder.getReport(new GapReport(searchFilters,

--- a/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImpl.java
@@ -53,7 +53,7 @@ public class GapReportServiceImpl implements GapReportService {
 
         final List<Map<String, Object>> results = gapReportRepository.getGapReport(searchFilters, groups);
 
-        final XSSFWorkbook workbook = gapReportBuilder.getReport(new GapReport(searchFilters,
+        final XSSFWorkbook workbook = gapReportBuilder.convertToReport(new GapReport(searchFilters,
                 groups,
                 results,
                 Instant.now()));

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
@@ -1,0 +1,123 @@
+package org.opentestsystem.ap.imrt.iss.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.opentestsystem.ap.imrt.common.config.OperationalEventConfiguration;
+import org.opentestsystem.ap.imrt.iss.config.JacksonObjectMapperConfiguration;
+import org.opentestsystem.ap.imrt.iss.dto.ItemDtoModelConverter;
+import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
+import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
+import org.opentestsystem.ap.imrt.iss.dto.search.MatchFilter;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilterConverter;
+import org.opentestsystem.ap.imrt.iss.service.GapReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_ID;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.CoreMatchers.is;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = ReportController.class)
+@Import({
+        JacksonObjectMapperConfiguration.class,
+        OperationalEventConfiguration.class,
+        ItemDtoModelConverter.class,
+        SearchFilterConverter.class
+})
+public class ReportControllerIntegrationTest {
+    @Autowired
+    private MockMvc http;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GapReportService gapReportService;
+
+    @Captor
+    private ArgumentCaptor<List<SearchFilter>> searchFiltersCaptor;
+
+    @Captor
+    private ArgumentCaptor<List<SearchProperty>> groupsCaptor;
+
+    @Test
+    public void shouldDownloadGapReport() throws Exception {
+        final String fileName = "gap-report-example.xlsx";
+        final File file = new File("/path/to/temp/dir/" + fileName);
+
+        final Filter subjectFilter = new MatchFilter(SUBJECT.getProperty(),
+                false,
+                Collections.singletonList("ELA"));
+        final List<String> groups = Arrays.asList(SUBJECT.getProperty(),
+                INTENDED_GRADE.getProperty(),
+                ITEM_TYPE.getProperty());
+        final GapReportRequest gapReportRequest = new GapReportRequest(Collections.singletonList(subjectFilter), groups);
+
+        final String gapReportRequestJson = objectMapper.writeValueAsString(gapReportRequest);
+
+        when(gapReportService.getGapReport(searchFiltersCaptor.capture(), groupsCaptor.capture()))
+                .thenReturn(Optional.of(file));
+
+        http.perform(post(new URI("/v1/items/reports/gap"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gapReportRequestJson)
+                .accept("*/*"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(header().string("Content-Disposition", "attachment; filename=" + fileName));
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenBadGroupsAreInRequest() throws Exception {
+        final Filter subjectFilter = new MatchFilter(SUBJECT.getProperty(),
+                false,
+                Collections.singletonList("ELA"));
+        final List<String> groups = Arrays.asList(SUBJECT.getProperty(),
+                INTENDED_GRADE.getProperty(),
+                ITEM_ID.getProperty());
+        final GapReportRequest gapReportRequest = new GapReportRequest(Collections.singletonList(subjectFilter), groups);
+
+        final String gapReportRequestJson = objectMapper.writeValueAsString(gapReportRequest);
+
+        when(gapReportService.getGapReport(searchFiltersCaptor.capture(), groupsCaptor.capture()))
+                .thenThrow(new IllegalArgumentException("The following group(s) are not supported: id"));
+
+        http.perform(post(new URI("/v1/items/reports/gap"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gapReportRequestJson)
+                .accept("*/*"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", is("The following group(s) are not supported: id")))
+                .andExpect(jsonPath("$.code", is("400")));
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mock;
 import org.opentestsystem.ap.imrt.common.config.OperationalEventConfiguration;
 import org.opentestsystem.ap.imrt.iss.config.JacksonObjectMapperConfiguration;
 import org.opentestsystem.ap.imrt.iss.dto.ItemDtoModelConverter;
@@ -13,7 +12,6 @@ import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
 import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
 import org.opentestsystem.ap.imrt.iss.dto.search.MatchFilter;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
-import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilterConverter;
 import org.opentestsystem.ap.imrt.iss.service.GapReportService;
@@ -25,7 +23,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
@@ -33,8 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_ID;
@@ -44,7 +40,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.hamcrest.CoreMatchers.is;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = ReportController.class)
@@ -119,5 +114,29 @@ public class ReportControllerIntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message", is("The following group(s) are not supported: id")))
                 .andExpect(jsonPath("$.code", is("400")));
+    }
+
+    @Test
+    public void shouldReturnNotFoundWhenFileIsNotCreated() throws Exception {
+        final Filter subjectFilter = new MatchFilter(SUBJECT.getProperty(),
+                false,
+                Collections.singletonList("ELA"));
+        final List<String> groups = Arrays.asList(SUBJECT.getProperty(),
+                INTENDED_GRADE.getProperty(),
+                ITEM_ID.getProperty());
+        final GapReportRequest gapReportRequest = new GapReportRequest(Collections.singletonList(subjectFilter), groups);
+
+        final String gapReportRequestJson = objectMapper.writeValueAsString(gapReportRequest);
+
+        when(gapReportService.getGapReport(searchFiltersCaptor.capture(), groupsCaptor.capture()))
+                .thenReturn(Optional.empty());
+
+        http.perform(post(new URI("/v1/items/reports/gap"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gapReportRequestJson)
+                .accept("*/*"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("could not get Gap Report file")))
+                .andExpect(jsonPath("$.code", is("404")));
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerIntegrationTest.java
@@ -112,6 +112,7 @@ public class ReportControllerIntegrationTest {
                 .content(gapReportRequestJson)
                 .accept("*/*"))
                 .andExpect(status().isBadRequest())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.message", is("The following group(s) are not supported: id")))
                 .andExpect(jsonPath("$.code", is("400")));
     }
@@ -136,6 +137,7 @@ public class ReportControllerIntegrationTest {
                 .content(gapReportRequestJson)
                 .accept("*/*"))
                 .andExpect(status().isNotFound())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.message", is("could not get Gap Report file")))
                 .andExpect(jsonPath("$.code", is("404")));
     }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerTest.java
@@ -1,0 +1,75 @@
+package org.opentestsystem.ap.imrt.iss.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
+import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
+import org.opentestsystem.ap.imrt.iss.dto.search.MatchFilter;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.ModelConverter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.service.GapReportService;
+import org.springframework.core.io.FileSystemResource;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReportControllerTest {
+    @Mock
+    private GapReportService mockGapReportService;
+
+    @Mock
+    private ModelConverter<Filter, SearchFilter> mockSearchFilterModelConverter;
+
+    @Mock
+    private HttpServletResponse mockHttpServletResponse;
+
+    private ReportController reportController;
+
+    @Before
+    public void setUp() {
+        reportController = new ReportController(mockGapReportService, mockSearchFilterModelConverter);
+    }
+
+    @Test
+    public void shouldReturnAGapReportFile() {
+        final Filter subjectFilter = new MatchFilter(SUBJECT.getProperty(),
+                false,
+                Collections.singletonList("ELA"));
+        final SearchFilter subjectSearchFilter = new MatchSearchFilter(SUBJECT, ((MatchFilter) subjectFilter).getValues());
+
+        final List<String> groups = Arrays.asList(SUBJECT.getProperty(),
+                INTENDED_GRADE.getProperty(),
+                ITEM_TYPE.getProperty());
+        final List<SearchProperty> groupProperties = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
+        final GapReportRequest gapReportRequest = new GapReportRequest(Collections.singletonList(subjectFilter), groups);
+
+        when(mockSearchFilterModelConverter.convert(Collections.singletonList(subjectFilter)))
+                .thenReturn(Collections.singletonList(subjectSearchFilter));
+        when(mockGapReportService.getGapReport(Collections.singletonList(subjectSearchFilter), groupProperties))
+                .thenReturn(Optional.of(new File("/path/to/temp/dir/gap-report-test.xlsx")));
+
+        final FileSystemResource result = reportController.getGapReport(gapReportRequest, mockHttpServletResponse);
+
+        verify(mockSearchFilterModelConverter).convert(Collections.singletonList(subjectFilter));
+        verify(mockGapReportService).getGapReport(Collections.singletonList(subjectSearchFilter), groupProperties);
+
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/controller/ReportControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.imrt.common.exception.NotFoundException;
 import org.opentestsystem.ap.imrt.iss.dto.search.Filter;
 import org.opentestsystem.ap.imrt.iss.dto.search.GapReportRequest;
 import org.opentestsystem.ap.imrt.iss.dto.search.MatchFilter;
@@ -71,5 +72,29 @@ public class ReportControllerTest {
         verify(mockGapReportService).getGapReport(Collections.singletonList(subjectSearchFilter), groupProperties);
 
         assertThat(result).isNotNull();
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void shouldThrowNotFoundExceptionWhenFileIsNotFound() {
+        final Filter subjectFilter = new MatchFilter(SUBJECT.getProperty(),
+                false,
+                Collections.singletonList("ELA"));
+        final SearchFilter subjectSearchFilter = new MatchSearchFilter(SUBJECT, ((MatchFilter) subjectFilter).getValues());
+
+        final List<String> groups = Arrays.asList(SUBJECT.getProperty(),
+                INTENDED_GRADE.getProperty(),
+                ITEM_TYPE.getProperty());
+        final List<SearchProperty> groupProperties = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
+        final GapReportRequest gapReportRequest = new GapReportRequest(Collections.singletonList(subjectFilter), groups);
+
+        when(mockSearchFilterModelConverter.convert(Collections.singletonList(subjectFilter)))
+                .thenReturn(Collections.singletonList(subjectSearchFilter));
+        when(mockGapReportService.getGapReport(Collections.singletonList(subjectSearchFilter), groupProperties))
+                .thenReturn(Optional.empty());
+
+        reportController.getGapReport(gapReportRequest, mockHttpServletResponse);
+
+        verify(mockSearchFilterModelConverter).convert(Collections.singletonList(subjectFilter));
+        verify(mockGapReportService).getGapReport(Collections.singletonList(subjectSearchFilter), groupProperties);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/model/GapReportBuilderTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/model/GapReportBuilderTest.java
@@ -8,12 +8,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
 import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField;
 
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +76,7 @@ public class GapReportBuilderTest {
                 Collections.singletonList(gapReportRecord),
                 Instant.now());
 
-        final XSSFWorkbook result = gapReportBuilder.getReport(gapReport);
+        final XSSFWorkbook result = gapReportBuilder.convertToReport(gapReport);
 
         assertThat(result).isNotNull();
         assertThat(result.getNumberOfSheets()).isEqualTo(2);

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/model/GapReportBuilderTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/model/GapReportBuilderTest.java
@@ -1,0 +1,100 @@
+package org.opentestsystem.ap.imrt.iss.model;
+
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_TWO;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GapReportBuilderTest {
+
+    private GapReportBuilder gapReportBuilder = new GapReportBuilder();
+
+    @Test
+    public void shouldBuildXSSFWorkbook() {
+        final Map<String, Object> gapReportRecord = new LinkedHashMap<>();
+        gapReportRecord.put(SUBJECT.getProperty().toLowerCase(), "ELA");
+        gapReportRecord.put(INTENDED_GRADE.getProperty().toLowerCase(), "3");
+        gapReportRecord.put(ITEM_TYPE.getProperty().toLowerCase(), "EQ");
+        gapReportRecord.put(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DESIRED_DIFFICULTY_ONE.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DESIRED_DIFFICULTY_TWO.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DESIRED_DIFFICULTY_THREE.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DESIRED_DIFFICULTY_FOUR.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DESIRED_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase(), 1);
+        gapReportRecord.put(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase(), 0);
+        gapReportRecord.put(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase(), 0);
+        gapReportRecord.put(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase(), 0);
+        gapReportRecord.put(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase(), 0);
+        gapReportRecord.put(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase(), 0);
+        gapReportRecord.put(DELTA_DIFFICULTY_ONE.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DELTA_DIFFICULTY_TWO.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DELTA_DIFFICULTY_THREE.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DELTA_DIFFICULTY_FOUR.getFieldName().toLowerCase(), "");
+        gapReportRecord.put(DELTA_DIFFICULTY_FIVE.getFieldName().toLowerCase(), "");
+
+        final List<SearchFilter> searchFilters =
+                Collections.singletonList(new MatchSearchFilter(SUBJECT, Collections.singletonList("ELA")));
+        final List<SearchProperty> groupFilters = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
+
+        final GapReport gapReport = new GapReport(searchFilters,
+                groupFilters,
+                Collections.singletonList(gapReportRecord),
+                Instant.now());
+
+        final XSSFWorkbook result = gapReportBuilder.getReport(gapReport);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNumberOfSheets()).isEqualTo(2);
+
+        final XSSFSheet reportParamsSheet = result.getSheetAt(0);
+        assertThat(reportParamsSheet.getSheetName()).isEqualTo("Report Parameters");
+        assertThat(reportParamsSheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Date Created");
+        assertThat(reportParamsSheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("Filters");
+        assertThat(reportParamsSheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("Subject");
+        assertThat(reportParamsSheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("ELA");
+        assertThat(reportParamsSheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("Groups");
+        assertThat(reportParamsSheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("Subject");
+        assertThat(reportParamsSheet.getRow(3).getCell(1).getStringCellValue()).isEqualTo("Intended Grade");
+        assertThat(reportParamsSheet.getRow(4).getCell(1).getStringCellValue()).isEqualTo("Type");
+
+        assertThat(result.getSheetAt(1).getSheetName()).isEqualTo("Report");
+        assertThat(result.getSheetAt(1).getLastRowNum()).isEqualTo(1);
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -2,7 +2,12 @@ package org.opentestsystem.ap.imrt.iss.repository;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.ap.common.model.EqItem;
+import org.opentestsystem.ap.common.model.McItem;
+import org.opentestsystem.ap.imrt.common.model.ImrtItem;
+import org.opentestsystem.ap.imrt.common.repository.ImrtItemRepository;
 import org.opentestsystem.ap.imrt.iss.ItemSearchServiceApplicationConfiguration;
+import org.opentestsystem.ap.imrt.iss.builder.ImrtItemBuilder;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,18 +31,78 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @EnableJpaAuditing
 public class GapReportRepositoryImplIntegrationTest {
     @Autowired
+    private ImrtItemRepository imrtItemRepository;
+
+    @Autowired
     private GapReportRepository gapReportRepository;
 
     @Test
     public void shouldGetGapReport() {
+        EqItem eq = new EqItem("123");
+        McItem mc = new McItem("345");
+        ImrtItem firstItem = new ImrtItemBuilder()
+                .withId(123)
+                .withItemJson(eq)
+                .withGrade("3")
+                .withSubject("ELA")
+                .withItemDifficultyQuintile(1)
+                .build();
+
+        ImrtItem secondItem = new ImrtItemBuilder()
+                .withId(345)
+                .withItemJson(mc)
+                .withGrade("4")
+                .withSubject("MATH")
+                .withItemType("MC")
+                .withItemDifficultyQuintile(2)
+                .build();
+
+        imrtItemRepository.save(Arrays.asList(firstItem, secondItem));
+
         final MatchSearchFilter subjectMatchFilter =
-                new MatchSearchFilter(SearchProperty.SUBJECT, Collections.singletonList("ELA"));
+                new MatchSearchFilter(SearchProperty.SUBJECT, Arrays.asList("ELA", "MATH"));
         final List<SearchProperty> searchProperties =
                 Arrays.asList(SearchProperty.SUBJECT, SearchProperty.INTENDED_GRADE, SearchProperty.ITEM_TYPE);
 
         final List<Map<String, Object>> result =
                 gapReportRepository.getGapReport(Collections.singletonList(subjectMatchFilter), searchProperties);
 
-        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+
+        final Map<String, Object> firstResult = result.get(0);
+        assertThat(firstResult.containsKey(SearchProperty.SUBJECT.getColumnName())).isTrue();
+        assertThat(firstResult.get(SearchProperty.SUBJECT.getColumnName())).isEqualTo("ELA");
+        assertThat(firstResult.containsKey(SearchProperty.INTENDED_GRADE.getColumnName())).isTrue();
+        assertThat(firstResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("3");
+        assertThat(firstResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
+        assertThat(firstResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("EQ");
+        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.get("difficulty_1")).isEqualTo(1L);
+        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.get("difficulty_2")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.get("difficulty_3")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.get("difficulty_4")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.get("difficulty_5")).isEqualTo(0L);
+
+        final Map<String, Object> secondResult = result.get(1);
+        assertThat(secondResult.containsKey(SearchProperty.SUBJECT.getColumnName())).isTrue();
+        assertThat(secondResult.get(SearchProperty.SUBJECT.getColumnName())).isEqualTo("MATH");
+        assertThat(secondResult.containsKey(SearchProperty.INTENDED_GRADE.getColumnName())).isTrue();
+        assertThat(secondResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("4");
+        assertThat(secondResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
+        assertThat(secondResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("MC");
+        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.get("difficulty_1")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.get("difficulty_2")).isEqualTo(1L);
+        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.get("difficulty_3")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.get("difficulty_4")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.get("difficulty_5")).isEqualTo(0L);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -10,6 +10,8 @@ import org.opentestsystem.ap.imrt.iss.ItemSearchServiceApplicationConfiguration;
 import org.opentestsystem.ap.imrt.iss.builder.ImrtItemBuilder;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -17,6 +19,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -107,5 +111,54 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(secondResult.get("actual_difficulty_4")).isEqualTo(0L);
         assertThat(secondResult.containsKey("actual_difficulty_5")).isTrue();
         assertThat(secondResult.get("actual_difficulty_5")).isEqualTo(0L);
+    }
+
+
+    @Test
+    public void shouldWriteExcelFile() throws IOException {
+        final EqItem eq = new EqItem("123");
+        final McItem mc = new McItem("345");
+        final McItem mc2 = new McItem("678");
+        final ImrtItem firstItem = new ImrtItemBuilder()
+                .withId(123)
+                .withItemJson(eq)
+                .withGrade("3")
+                .withSubject("ELA")
+                .withItemDifficultyQuintile(1)
+                .build();
+        final ImrtItem secondItem = new ImrtItemBuilder()
+                .withId(345)
+                .withItemJson(mc)
+                .withGrade("4")
+                .withSubject("MATH")
+                .withItemType("MC")
+                .withItemDifficultyQuintile(2)
+                .build();
+        final ImrtItem thirdItem = new ImrtItemBuilder()
+                .withId(678)
+                .withItemJson(mc2)
+                .withGrade("3")
+                .withSubject("MATH")
+                .withItemType("MC")
+                .withItemDifficultyQuintile(3)
+                .build();
+        imrtItemRepository.save(Arrays.asList(firstItem, secondItem, thirdItem));
+
+        final MatchSearchFilter subjectMatchFilter =
+                new MatchSearchFilter(SearchProperty.SUBJECT, Arrays.asList("ELA", "MATH", "foo", "bar"));
+        final MatchSearchFilter gradeMatchFilter =
+                new MatchSearchFilter(SearchProperty.INTENDED_GRADE, Arrays.asList("3", "4"));
+        final List<SearchProperty> searchProperties =
+                Arrays.asList(SearchProperty.SUBJECT, SearchProperty.INTENDED_GRADE, SearchProperty.ITEM_TYPE);
+
+        final List<Map<String, Object>> result =
+                gapReportRepository.getGapReport(Arrays.asList(subjectMatchFilter, gradeMatchFilter), searchProperties);
+
+        final GapReportBuilder gapReportBuilder = new GapReportBuilder();
+        final GapReport testGapReport = new GapReport(Arrays.asList(subjectMatchFilter, gradeMatchFilter),
+                searchProperties,
+                result,
+                Instant.now());
+        gapReportBuilder.getReport(testGapReport);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -10,8 +10,6 @@ import org.opentestsystem.ap.imrt.iss.ItemSearchServiceApplicationConfiguration;
 import org.opentestsystem.ap.imrt.iss.builder.ImrtItemBuilder;
 import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
 import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
-import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -19,14 +17,30 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.ACTUAL_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DELTA_DIFFICULTY_TWO;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_COUNT;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FIVE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_FOUR;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_ONE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_THREE;
+import static org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportCalculationField.DESIRED_DIFFICULTY_TWO;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -73,92 +87,115 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(result).hasSize(2);
 
         final Map<String, Object> firstResult = result.get(0);
-        assertThat(firstResult.containsKey(SearchProperty.SUBJECT.getColumnName())).isTrue();
-        assertThat(firstResult.get(SearchProperty.SUBJECT.getColumnName())).isEqualTo("ELA");
-        assertThat(firstResult.containsKey(SearchProperty.INTENDED_GRADE.getColumnName())).isTrue();
-        assertThat(firstResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("3");
-        assertThat(firstResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
-        assertThat(firstResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("EQ");
-        assertThat(firstResult.containsKey("actual")).isTrue();
-        assertThat(firstResult.get("actual")).isEqualTo(1L);
-        assertThat(firstResult.containsKey("actual_difficulty_1")).isTrue();
-        assertThat(firstResult.get("actual_difficulty_1")).isEqualTo(1L);
-        assertThat(firstResult.containsKey("actual_difficulty_2")).isTrue();
-        assertThat(firstResult.get("actual_difficulty_2")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("actual_difficulty_3")).isTrue();
-        assertThat(firstResult.get("actual_difficulty_3")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("actual_difficulty_4")).isTrue();
-        assertThat(firstResult.get("actual_difficulty_4")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("actual_difficulty_5")).isTrue();
-        assertThat(firstResult.get("actual_difficulty_5")).isEqualTo(0L);
+        assertThat(firstResult.containsKey(SearchProperty.SUBJECT.getProperty().toLowerCase())).isTrue();
+        assertThat(firstResult.get(SearchProperty.SUBJECT.getProperty().toLowerCase())).isEqualTo("ELA");
+        assertThat(firstResult.containsKey(SearchProperty.INTENDED_GRADE.getProperty().toLowerCase())).isTrue();
+        assertThat(firstResult.get(SearchProperty.INTENDED_GRADE.getProperty().toLowerCase())).isEqualTo("3");
+        assertThat(firstResult.containsKey(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isTrue();
+        assertThat(firstResult.get(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isEqualTo("EQ");
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DESIRED_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isEqualTo(1L);
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase())).isEqualTo(1L);
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(firstResult.containsKey(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.get(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(firstResult.containsKey(DELTA_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
+
 
         final Map<String, Object> secondResult = result.get(1);
-        assertThat(secondResult.containsKey(SearchProperty.SUBJECT.getColumnName())).isTrue();
-        assertThat(secondResult.get(SearchProperty.SUBJECT.getColumnName())).isEqualTo("MATH");
-        assertThat(secondResult.containsKey(SearchProperty.INTENDED_GRADE.getColumnName())).isTrue();
-        assertThat(secondResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("4");
-        assertThat(secondResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
-        assertThat(secondResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("MC");
-        assertThat(firstResult.containsKey("actual")).isTrue();
-        assertThat(firstResult.get("actual")).isEqualTo(1L);
-        assertThat(secondResult.containsKey("actual_difficulty_1")).isTrue();
-        assertThat(secondResult.get("actual_difficulty_1")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("actual_difficulty_2")).isTrue();
-        assertThat(secondResult.get("actual_difficulty_2")).isEqualTo(1L);
-        assertThat(secondResult.containsKey("actual_difficulty_3")).isTrue();
-        assertThat(secondResult.get("actual_difficulty_3")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("actual_difficulty_4")).isTrue();
-        assertThat(secondResult.get("actual_difficulty_4")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("actual_difficulty_5")).isTrue();
-        assertThat(secondResult.get("actual_difficulty_5")).isEqualTo(0L);
+        assertThat(secondResult.containsKey(SearchProperty.SUBJECT.getProperty().toLowerCase())).isTrue();
+        assertThat(secondResult.get(SearchProperty.SUBJECT.getProperty().toLowerCase())).isEqualTo("MATH");
+        assertThat(secondResult.containsKey(SearchProperty.INTENDED_GRADE.getProperty().toLowerCase())).isTrue();
+        assertThat(secondResult.get(SearchProperty.INTENDED_GRADE.getProperty().toLowerCase())).isEqualTo("4");
+        assertThat(secondResult.containsKey(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isTrue();
+        assertThat(secondResult.get(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isEqualTo("MC");
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DESIRED_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isEqualTo(1L);
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_ONE.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_TWO.getFieldName().toLowerCase())).isEqualTo(1L);
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_THREE.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(secondResult.containsKey(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.get(ACTUAL_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isEqualTo(0L);
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_COUNT.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_ONE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_TWO.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_THREE.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_FOUR.getFieldName().toLowerCase())).isTrue();
+        assertThat(secondResult.containsKey(DELTA_DIFFICULTY_FIVE.getFieldName().toLowerCase())).isTrue();
     }
 
-
     @Test
-    public void shouldWriteExcelFile() throws IOException {
+    public void shouldExcludeStimulusAndTutorialItemsFromResults() {
         final EqItem eq = new EqItem("123");
         final McItem mc = new McItem("345");
-        final McItem mc2 = new McItem("678");
-        final ImrtItem firstItem = new ImrtItemBuilder()
+        final McItem secondMc = new McItem("678");
+        final ImrtItem tutItem = new ImrtItemBuilder()
                 .withId(123)
                 .withItemJson(eq)
                 .withGrade("3")
                 .withSubject("ELA")
+                .withItemType("tut")
                 .withItemDifficultyQuintile(1)
                 .build();
-        final ImrtItem secondItem = new ImrtItemBuilder()
+        final ImrtItem stimItem = new ImrtItemBuilder()
                 .withId(345)
                 .withItemJson(mc)
+                .withGrade("4")
+                .withSubject("MATH")
+                .withItemType("stim")
+                .withItemDifficultyQuintile(2)
+                .build();
+        final ImrtItem mcItem = new ImrtItemBuilder()
+                .withId(678)
+                .withItemJson(secondMc)
                 .withGrade("4")
                 .withSubject("MATH")
                 .withItemType("MC")
                 .withItemDifficultyQuintile(2)
                 .build();
-        final ImrtItem thirdItem = new ImrtItemBuilder()
-                .withId(678)
-                .withItemJson(mc2)
-                .withGrade("3")
-                .withSubject("MATH")
-                .withItemType("MC")
-                .withItemDifficultyQuintile(3)
-                .build();
-        // imrtItemRepository.save(Arrays.asList(firstItem, secondItem, thirdItem));
+
+        imrtItemRepository.save(Arrays.asList(tutItem, stimItem, mcItem));
 
         final MatchSearchFilter subjectMatchFilter =
-                new MatchSearchFilter(SearchProperty.SUBJECT, Arrays.asList("ELA", "MATH", "foo", "bar"));
-        final MatchSearchFilter gradeMatchFilter =
-                new MatchSearchFilter(SearchProperty.INTENDED_GRADE, Arrays.asList("3", "4"));
+                new MatchSearchFilter(SearchProperty.SUBJECT, Arrays.asList("ELA", "MATH"));
         final List<SearchProperty> searchProperties =
                 Arrays.asList(SearchProperty.SUBJECT, SearchProperty.INTENDED_GRADE, SearchProperty.ITEM_TYPE);
 
         final List<Map<String, Object>> result =
-                gapReportRepository.getGapReport(Arrays.asList(subjectMatchFilter, gradeMatchFilter), searchProperties);
+                gapReportRepository.getGapReport(Collections.singletonList(subjectMatchFilter), searchProperties);
 
-        final GapReportBuilder gapReportBuilder = new GapReportBuilder();
-        final GapReport testGapReport = new GapReport(Arrays.asList(subjectMatchFilter, gradeMatchFilter),
-                searchProperties,
-                result,
-                Instant.now());
-        gapReportBuilder.getReport(testGapReport);
+        assertThat(result).hasSize(1);
+
+        final Map<String, Object> resultItem = result.get(0);
+        assertThat(resultItem.containsKey(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isTrue();
+        assertThat(resultItem.get(SearchProperty.ITEM_TYPE.getProperty().toLowerCase())).isEqualTo("MC");
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -142,7 +142,7 @@ public class GapReportRepositoryImplIntegrationTest {
                 .withItemType("MC")
                 .withItemDifficultyQuintile(3)
                 .build();
-        imrtItemRepository.save(Arrays.asList(firstItem, secondItem, thirdItem));
+        // imrtItemRepository.save(Arrays.asList(firstItem, secondItem, thirdItem));
 
         final MatchSearchFilter subjectMatchFilter =
                 new MatchSearchFilter(SearchProperty.SUBJECT, Arrays.asList("ELA", "MATH", "foo", "bar"));

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -38,17 +38,16 @@ public class GapReportRepositoryImplIntegrationTest {
 
     @Test
     public void shouldGetGapReport() {
-        EqItem eq = new EqItem("123");
-        McItem mc = new McItem("345");
-        ImrtItem firstItem = new ImrtItemBuilder()
+        final EqItem eq = new EqItem("123");
+        final McItem mc = new McItem("345");
+        final ImrtItem firstItem = new ImrtItemBuilder()
                 .withId(123)
                 .withItemJson(eq)
                 .withGrade("3")
                 .withSubject("ELA")
                 .withItemDifficultyQuintile(1)
                 .build();
-
-        ImrtItem secondItem = new ImrtItemBuilder()
+        final ImrtItem secondItem = new ImrtItemBuilder()
                 .withId(345)
                 .withItemJson(mc)
                 .withGrade("4")
@@ -78,13 +77,13 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(firstResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("EQ");
         assertThat(firstResult.containsKey("difficulty_1")).isTrue();
         assertThat(firstResult.get("difficulty_1")).isEqualTo(1L);
-        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.containsKey("difficulty_2")).isTrue();
         assertThat(firstResult.get("difficulty_2")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.containsKey("difficulty_3")).isTrue();
         assertThat(firstResult.get("difficulty_3")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.containsKey("difficulty_4")).isTrue();
         assertThat(firstResult.get("difficulty_4")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
+        assertThat(firstResult.containsKey("difficulty_5")).isTrue();
         assertThat(firstResult.get("difficulty_5")).isEqualTo(0L);
 
         final Map<String, Object> secondResult = result.get(1);
@@ -96,13 +95,13 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(secondResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("MC");
         assertThat(secondResult.containsKey("difficulty_1")).isTrue();
         assertThat(secondResult.get("difficulty_1")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.containsKey("difficulty_2")).isTrue();
         assertThat(secondResult.get("difficulty_2")).isEqualTo(1L);
-        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.containsKey("difficulty_3")).isTrue();
         assertThat(secondResult.get("difficulty_3")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.containsKey("difficulty_4")).isTrue();
         assertThat(secondResult.get("difficulty_4")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
+        assertThat(secondResult.containsKey("difficulty_5")).isTrue();
         assertThat(secondResult.get("difficulty_5")).isEqualTo(0L);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -1,0 +1,43 @@
+package org.opentestsystem.ap.imrt.iss.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.ap.imrt.iss.ItemSearchServiceApplicationConfiguration;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+@Import(ItemSearchServiceApplicationConfiguration.class)
+@EnableJpaAuditing
+public class GapReportRepositoryImplIntegrationTest {
+    @Autowired
+    private GapReportRepository gapReportRepository;
+
+    @Test
+    public void shouldGetGapReport() {
+        final MatchSearchFilter subjectMatchFilter =
+                new MatchSearchFilter(SearchProperty.SUBJECT, Collections.singletonList("ELA"));
+        final List<SearchProperty> searchProperties =
+                Arrays.asList(SearchProperty.SUBJECT, SearchProperty.INTENDED_GRADE, SearchProperty.ITEM_TYPE);
+
+        final List<Map<String, Object>> result =
+                gapReportRepository.getGapReport(Collections.singletonList(subjectMatchFilter), searchProperties);
+
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/repository/GapReportRepositoryImplIntegrationTest.java
@@ -75,16 +75,18 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(firstResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("3");
         assertThat(firstResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
         assertThat(firstResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("EQ");
-        assertThat(firstResult.containsKey("difficulty_1")).isTrue();
-        assertThat(firstResult.get("difficulty_1")).isEqualTo(1L);
-        assertThat(firstResult.containsKey("difficulty_2")).isTrue();
-        assertThat(firstResult.get("difficulty_2")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_3")).isTrue();
-        assertThat(firstResult.get("difficulty_3")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_4")).isTrue();
-        assertThat(firstResult.get("difficulty_4")).isEqualTo(0L);
-        assertThat(firstResult.containsKey("difficulty_5")).isTrue();
-        assertThat(firstResult.get("difficulty_5")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("actual")).isTrue();
+        assertThat(firstResult.get("actual")).isEqualTo(1L);
+        assertThat(firstResult.containsKey("actual_difficulty_1")).isTrue();
+        assertThat(firstResult.get("actual_difficulty_1")).isEqualTo(1L);
+        assertThat(firstResult.containsKey("actual_difficulty_2")).isTrue();
+        assertThat(firstResult.get("actual_difficulty_2")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("actual_difficulty_3")).isTrue();
+        assertThat(firstResult.get("actual_difficulty_3")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("actual_difficulty_4")).isTrue();
+        assertThat(firstResult.get("actual_difficulty_4")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("actual_difficulty_5")).isTrue();
+        assertThat(firstResult.get("actual_difficulty_5")).isEqualTo(0L);
 
         final Map<String, Object> secondResult = result.get(1);
         assertThat(secondResult.containsKey(SearchProperty.SUBJECT.getColumnName())).isTrue();
@@ -93,15 +95,17 @@ public class GapReportRepositoryImplIntegrationTest {
         assertThat(secondResult.get(SearchProperty.INTENDED_GRADE.getColumnName())).isEqualTo("4");
         assertThat(secondResult.containsKey(SearchProperty.ITEM_TYPE.getColumnName())).isTrue();
         assertThat(secondResult.get(SearchProperty.ITEM_TYPE.getColumnName())).isEqualTo("MC");
-        assertThat(secondResult.containsKey("difficulty_1")).isTrue();
-        assertThat(secondResult.get("difficulty_1")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_2")).isTrue();
-        assertThat(secondResult.get("difficulty_2")).isEqualTo(1L);
-        assertThat(secondResult.containsKey("difficulty_3")).isTrue();
-        assertThat(secondResult.get("difficulty_3")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_4")).isTrue();
-        assertThat(secondResult.get("difficulty_4")).isEqualTo(0L);
-        assertThat(secondResult.containsKey("difficulty_5")).isTrue();
-        assertThat(secondResult.get("difficulty_5")).isEqualTo(0L);
+        assertThat(firstResult.containsKey("actual")).isTrue();
+        assertThat(firstResult.get("actual")).isEqualTo(1L);
+        assertThat(secondResult.containsKey("actual_difficulty_1")).isTrue();
+        assertThat(secondResult.get("actual_difficulty_1")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("actual_difficulty_2")).isTrue();
+        assertThat(secondResult.get("actual_difficulty_2")).isEqualTo(1L);
+        assertThat(secondResult.containsKey("actual_difficulty_3")).isTrue();
+        assertThat(secondResult.get("actual_difficulty_3")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("actual_difficulty_4")).isTrue();
+        assertThat(secondResult.get("actual_difficulty_4")).isEqualTo(0L);
+        assertThat(secondResult.containsKey("actual_difficulty_5")).isTrue();
+        assertThat(secondResult.get("actual_difficulty_5")).isEqualTo(0L);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
@@ -60,7 +60,7 @@ public class GapReportServiceImplTest {
 
         when(mockGapReportRepository.getGapReport(searchFilters, groups))
                 .thenReturn(Collections.singletonList(gapReportRecord));
-        when(mockGapReportBuilder.getReport(isA(GapReport.class)))
+        when(mockGapReportBuilder.convertToReport(isA(GapReport.class)))
                 .thenReturn(new XSSFWorkbook());
 
         final Optional<File> result = gapReportService.getGapReport(searchFilters, groups);

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
@@ -1,0 +1,83 @@
+package org.opentestsystem.ap.imrt.iss.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty;
+import org.opentestsystem.ap.imrt.iss.model.IdMatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GapReportServiceImplTest {
+    @Mock
+    private GapReportRepository mockGapReportRepository;
+
+    private GapReportService gapReportService;
+
+    @Before
+    public void setup() {
+        gapReportService = new GapReportServiceImpl(mockGapReportRepository);
+    }
+
+    @Test
+    public void shouldGetGapReport() {
+        final Map<String, Object> gapReportRecord = new HashMap<>();
+        gapReportRecord.put(SUBJECT.getColumnName(), "ELA");
+        gapReportRecord.put(INTENDED_GRADE.getColumnName(), "3");
+        gapReportRecord.put(ITEM_TYPE.getColumnName(), "EQ");
+
+        final List<SearchFilter> searchFilters =
+                Collections.singletonList(new MatchSearchFilter(SUBJECT, Collections.singletonList("ELA")));
+        final List<SearchProperty> groupFilters = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
+
+        when(mockGapReportRepository.getGapReport(searchFilters, groupFilters))
+                .thenReturn(Collections.singletonList(gapReportRecord));
+
+        final Optional<GapReport> result = gapReportService.getGapReport(searchFilters, groupFilters);
+
+        verify(mockGapReportRepository).getGapReport(searchFilters, groupFilters);
+
+        assertThat(result).isPresent();
+
+        final GapReport gapReport = result.get();
+        assertThat(gapReport.getFilters()).containsExactly(searchFilters.toArray(new SearchFilter[0]));
+        assertThat(gapReport.getGroupFilters()).containsExactly(groupFilters.toArray(new SearchProperty[0]));
+        assertThat(gapReport.getGapReportRecords()).containsExactly(gapReportRecord);
+        assertThat(gapReport.getCreatedDate()).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+    }
+
+    @Test
+    public void shouldReturnOptionalEmptyWhenSuppliedWithInvalidSearchFilters() {
+        final IdMatchSearchFilter emptyIdMatchFilter = new IdMatchSearchFilter(SearchProperty.ITEM_ID,
+                Collections.singletonList("foo"));
+
+        final Optional<GapReport> result = gapReportService.getGapReport(Collections.singletonList(emptyIdMatchFilter),
+                Collections.singletonList(SUBJECT));
+
+        assertThat(result).isNotPresent();
+        verifyZeroInteractions(mockGapReportRepository);
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
@@ -10,8 +10,10 @@ import org.opentestsystem.ap.imrt.iss.model.IdMatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.MatchSearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.SearchFilter;
 import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReport;
+import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
 
+import java.io.File;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -35,11 +37,14 @@ public class GapReportServiceImplTest {
     @Mock
     private GapReportRepository mockGapReportRepository;
 
+    @Mock
+    private GapReportBuilder mockGapReportBuilder;
+
     private GapReportService gapReportService;
 
     @Before
     public void setup() {
-        gapReportService = new GapReportServiceImpl(mockGapReportRepository);
+        gapReportService = new GapReportServiceImpl(mockGapReportRepository, mockGapReportBuilder);
     }
 
     @Test
@@ -56,17 +61,17 @@ public class GapReportServiceImplTest {
         when(mockGapReportRepository.getGapReport(searchFilters, groupFilters))
                 .thenReturn(Collections.singletonList(gapReportRecord));
 
-        final Optional<GapReport> result = gapReportService.getGapReport(searchFilters, groupFilters);
+        final Optional<File> result = gapReportService.getGapReport(searchFilters, groupFilters);
 
         verify(mockGapReportRepository).getGapReport(searchFilters, groupFilters);
 
         assertThat(result).isPresent();
 
-        final GapReport gapReport = result.get();
-        assertThat(gapReport.getFilters()).containsExactly(searchFilters.toArray(new SearchFilter[0]));
-        assertThat(gapReport.getGroupFilters()).containsExactly(groupFilters.toArray(new SearchProperty[0]));
-        assertThat(gapReport.getGapReportRecords()).containsExactly(gapReportRecord);
-        assertThat(gapReport.getCreatedDate()).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+        final File gapReport = result.get();
+//        assertThat(gapReport.getFilters()).containsExactly(searchFilters.toArray(new SearchFilter[0]));
+//        assertThat(gapReport.getGroupFilters()).containsExactly(groupFilters.toArray(new SearchProperty[0]));
+//        assertThat(gapReport.getGapReportRecords()).containsExactly(gapReportRecord);
+//        assertThat(gapReport.getCreatedDate()).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
     }
 
     @Test
@@ -74,7 +79,7 @@ public class GapReportServiceImplTest {
         final IdMatchSearchFilter emptyIdMatchFilter = new IdMatchSearchFilter(SearchProperty.ITEM_ID,
                 Collections.singletonList("foo"));
 
-        final Optional<GapReport> result = gapReportService.getGapReport(Collections.singletonList(emptyIdMatchFilter),
+        final Optional<File> result = gapReportService.getGapReport(Collections.singletonList(emptyIdMatchFilter),
                 Collections.singletonList(SUBJECT));
 
         assertThat(result).isNotPresent();

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.imrt.iss.service;
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,8 +15,6 @@ import org.opentestsystem.ap.imrt.iss.model.reports.gap.GapReportBuilder;
 import org.opentestsystem.ap.imrt.iss.repository.GapReportRepository;
 
 import java.io.File;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -50,9 +49,9 @@ public class GapReportServiceImplTest {
     @Test
     public void shouldGetGapReport() {
         final Map<String, Object> gapReportRecord = new HashMap<>();
-        gapReportRecord.put(SUBJECT.getColumnName(), "ELA");
-        gapReportRecord.put(INTENDED_GRADE.getColumnName(), "3");
-        gapReportRecord.put(ITEM_TYPE.getColumnName(), "EQ");
+        gapReportRecord.put(SUBJECT.getProperty().toLowerCase(), "ELA");
+        gapReportRecord.put(INTENDED_GRADE.getProperty().toLowerCase(), "3");
+        gapReportRecord.put(ITEM_TYPE.getProperty().toLowerCase(), "EQ");
 
         final List<SearchFilter> searchFilters =
                 Collections.singletonList(new MatchSearchFilter(SUBJECT, Collections.singletonList("ELA")));
@@ -60,6 +59,8 @@ public class GapReportServiceImplTest {
 
         when(mockGapReportRepository.getGapReport(searchFilters, groupFilters))
                 .thenReturn(Collections.singletonList(gapReportRecord));
+        when(mockGapReportBuilder.getReport(isA(GapReport.class)))
+                .thenReturn(new XSSFWorkbook());
 
         final Optional<File> result = gapReportService.getGapReport(searchFilters, groupFilters);
 
@@ -67,11 +68,8 @@ public class GapReportServiceImplTest {
 
         assertThat(result).isPresent();
 
-        final File gapReport = result.get();
-//        assertThat(gapReport.getFilters()).containsExactly(searchFilters.toArray(new SearchFilter[0]));
-//        assertThat(gapReport.getGroupFilters()).containsExactly(groupFilters.toArray(new SearchProperty[0]));
-//        assertThat(gapReport.getGapReportRecords()).containsExactly(gapReportRecord);
-//        assertThat(gapReport.getCreatedDate()).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+        final File resultFile = result.get();
+        assertThat(resultFile.getName()).startsWith("gap-report-");
     }
 
     @Test
@@ -84,5 +82,6 @@ public class GapReportServiceImplTest {
 
         assertThat(result).isNotPresent();
         verifyZeroInteractions(mockGapReportRepository);
+        verifyZeroInteractions(mockGapReportBuilder);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iss/service/GapReportServiceImplTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.INTENDED_GRADE;
+import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_ID;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.ITEM_TYPE;
 import static org.opentestsystem.ap.imrt.iss.dto.search.SearchProperty.SUBJECT;
 
@@ -55,16 +56,16 @@ public class GapReportServiceImplTest {
 
         final List<SearchFilter> searchFilters =
                 Collections.singletonList(new MatchSearchFilter(SUBJECT, Collections.singletonList("ELA")));
-        final List<SearchProperty> groupFilters = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
+        final List<SearchProperty> groups = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE);
 
-        when(mockGapReportRepository.getGapReport(searchFilters, groupFilters))
+        when(mockGapReportRepository.getGapReport(searchFilters, groups))
                 .thenReturn(Collections.singletonList(gapReportRecord));
         when(mockGapReportBuilder.getReport(isA(GapReport.class)))
                 .thenReturn(new XSSFWorkbook());
 
-        final Optional<File> result = gapReportService.getGapReport(searchFilters, groupFilters);
+        final Optional<File> result = gapReportService.getGapReport(searchFilters, groups);
 
-        verify(mockGapReportRepository).getGapReport(searchFilters, groupFilters);
+        verify(mockGapReportRepository).getGapReport(searchFilters, groups);
 
         assertThat(result).isPresent();
 
@@ -83,5 +84,14 @@ public class GapReportServiceImplTest {
         assertThat(result).isNotPresent();
         verifyZeroInteractions(mockGapReportRepository);
         verifyZeroInteractions(mockGapReportBuilder);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenGivenInvalidGroups() {
+        final List<SearchFilter> searchFilters =
+                Collections.singletonList(new MatchSearchFilter(SUBJECT, Collections.singletonList("ELA")));
+        final List<SearchProperty> groups = Arrays.asList(SUBJECT, INTENDED_GRADE, ITEM_TYPE, ITEM_ID);
+
+        final Optional<File> result = gapReportService.getGapReport(searchFilters, groups);
     }
 }


### PR DESCRIPTION
[IAT-2095](https://jira.fairwaytech.com/browse/IAT-2095):  Gap Report support
* Two tabs:
  * **Report Parameters:** shows the date the report was created, the filters & groups supplied by the user
  * **Report Details:** shows the details of the report
* The report data excludes `STIM` and `TUT` items; items of these types are not included in the counts
* Formulae are present; the user only has to type into the yellow "Desired" column and the spreadsheet takes care of the rest